### PR TITLE
In SUPREMM realm, corrected the where condition fields on fos_table f…

### DIFF
--- a/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByNsfdirectorate.php
+++ b/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByNsfdirectorate.php
@@ -121,7 +121,7 @@ class GroupByNSFDirectorate extends \DataWarehouse\Query\SUPREMM\GroupBy
         // construct the join between the main data_table and this group by table
         $query->addTable($this->fos_table);
 
-        $fostable_id_field = new \DataWarehouse\Query\Model\TableField($this->fos_table,'id');
+        $fostable_id_field = new \DataWarehouse\Query\Model\TableField($this->fos_table,'directorate_id');
         $datatable_fos_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'fos_id');
 
         // construct the join between the main data_table and this group by table

--- a/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByParentscience.php
+++ b/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByParentscience.php
@@ -81,7 +81,7 @@ class GroupByParentScience extends \DataWarehouse\Query\SUPREMM\GroupBy
         // construct the join between the main data_table and this group by table
         $query->addTable($this->fos_table);
 
-        $fostable_id_field = new \DataWarehouse\Query\Model\TableField($this->fos_table,'id');
+        $fostable_id_field = new \DataWarehouse\Query\Model\TableField($this->fos_table,'parent_id');
         $datatable_fos_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'fos_id');
 
         // construct the join between the main data_table and this group by table


### PR DESCRIPTION
Summarization of undisplayed datasets was instead summing ALL datasets for group bys associated with the field of science_hierarchy table. This was seen only in timeseries plots. Small fixes to the where conditions used to generate the summarizations were needed in the GroupBy child classes for ParentScience and NSFDirectorate.

A fix provided for previous pull request accounted for Jobs realm code but not SUPREMM realm code. The present fix is to the SUPREMM realm code.

## Description
We corrected join fields on fos_table for parent science and nsfdirectorate so that top-n values will be excluded from summary calculation as intended. This field of science hierarchy table contains three ways of looking at the science hierarchy; field of science, parent science, and directorate. The fos id was incorrectly used in all three of the group bys that use this table.

Now that the where clauses are correct, the data series that are plotted are correctly excluded from summarization. The present fix addresses the SUPREMM realm only.

## Motivation and Context
Open issue:
https://app.asana.com/0/14787510600562/229260587300103

## Tests performed
Verified here in Usage tab of xdmod-dev and xdmod-dev port 9004, 14 Dec 16:

SUPREMM summary: CPU hours total: drill down by NSFDirectorate. Plot top 8 datasets; all are shown. Plot top 5 datasets. Summarization is shown to be correctly performed. In the buggy case, the summarization was incorrectly summing over all datasets.

Parent Science: Perform same demonstration as above (top 10 datasets vs. 126 'other').

Field of Science: While this GroupBy appears to suffer from the same bug, note that the number of possible fields of science number in the hundreds. Plot top 5, then top 50, and note that the Remainder field drops precipitously. The where condition is correct and the underlying query can be seen to exclude the already-plotted datasets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.