### PR TITLE
SUPREMM: Removed overrides to show error bars in child of GroupBy class.

### DIFF
--- a/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByNsfdirectorate.php
+++ b/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByNsfdirectorate.php
@@ -62,10 +62,6 @@ class GroupByNSFDirectorate extends \DataWarehouse\Query\SUPREMM\GroupBy
    {
       return 'y';
    }
-   public function getDefaultShowErrorBars()
-   {
-       return 'n';
-   }
    public function getDefaultShowGuideLines()
    {
        return 'n';


### PR DESCRIPTION
Error bar datasets will no longer be plotted by default in Usage tab. Parent GroupBy class now turns off error bar display; child classes do not override this setting.

Refer to pull request ubccr/xdmod/#6 which takes care of this change in base code.

## Description
This change affects only the Jobs realm "Per Job" (Average) plots, which are the only places where standard deviation datasets are generated and available to plot as error bars.

## Motivation and Context
Feature request and further discussion:
https://app.asana.com/0/14787510600562/217118195806574

## Tests performed
Jobs realm "Per Job" Usage plots have been verified to be free of error bars by default. Error bars confirmed available to plot as the user wishes.

## Types of changes
This may depend on your definition of "breaking". All Jobs realm plots that report averages are now plotted in Usage tab without error bars due to this change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
