### PR TITLE
Added documentation for updating npm dependencies after updating via RPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Open XDMoD SUPReMM Change Log
 2016-12-22 v6.5.0
 -----------------
 
+**Important Note**: This update adds a dependency to npm. If you are updating
+an existing installation via RPM, you will need to reinstall npm
+dependencies afterward. To do this, run the commands below.
+
+```bash
+# Assuming XDMoD's share directory is RPM default "/usr/share/xdmod"
+
+cd /usr/share/xdmod/etl/js
+npm install
+```
+
 - Features
     - General
         - Added peak memory usage metric.

--- a/docs/supremm-upgrade.md
+++ b/docs/supremm-upgrade.md
@@ -12,6 +12,17 @@ page](http://open.xdmod.org/upgrade.html).
 6.0.0 to 6.5.0 Upgrade Notes
 ----------------------------
 
+**Important Note**: This update adds a dependency to npm. If you are updating
+an existing installation via RPM, you will need to reinstall npm
+dependencies afterward. To do this, run the commands below.
+
+```bash
+# Assuming XDMoD's share directory is RPM default "/usr/share/xdmod"
+
+cd /usr/share/xdmod/etl/js
+npm install
+```
+
 - This upgrade includes database schema changes.
     - Modifies `modw_supremm` schema.
     - Modifies `modw_aggregates` schema.

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -51,6 +51,11 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 * Thu Dec 22 2016 Jeffrey T. Palmer <jtpalmer@buffalo.edu> 6.5.0-1.0
+- Important Notes
+    - This update adds a dependency to npm. If you are updating from a previous
+      version installed via RPM, you will need to reinstall npm dependencies
+      afterward. From the `etl/js` directory inside the XDMoD share directory
+      (RPM default: `/usr/share/xdmod`), run `npm install`.
 - Features
     - General
         - Added peak memory usage metric.


### PR DESCRIPTION
## Description
Since v6.5.0 moves a dependency into npm, this dependency needs to be installed on upgrade. This happens naturally as part of source upgrades, but not as part of RPM upgrades. This pull request makes it clear what needs to be done to get an RPM install back up and running.

In a future Open XDMoD release, npm dependencies will be included with packages and their setup will be better automated.

## Tests performed
Checked that Markdown was valid.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~All new and existing tests passed.~~
