### PR TITLE
Add support for a debug cmdline flag.

### DIFF
--- a/bin/aggregate_supremm.sh
+++ b/bin/aggregate_supremm.sh
@@ -10,15 +10,22 @@ reportfail()
     exit 1
 }
 
+if [ "$1" = "-d" ];
+then
+    FLAGS="-d"
+else
+    FLAGS="-q"
+fi
+
 (
     flock -n 9 || reportfail
 
     cd ${XDMOD_SHARE_PATH}/etl/js
     
-    node etl.cluster.js -q
+    node etl.cluster.js $FLAGS
     
-    php ${XDMOD_LIB_PATH}/supremm_sharedjobs.php -q
+    php ${XDMOD_LIB_PATH}/supremm_sharedjobs.php $FLAGS
     
-    php ${XDMOD_LIB_PATH}/aggregate_supremm.php -q
+    php ${XDMOD_LIB_PATH}/aggregate_supremm.php $FLAGS
 
 ) 9>${LOCKFILE}


### PR DESCRIPTION
Add support for a debug cmdline flag.

## Description
Adds a -d flag to call all subprocesses with the debug log on.

## Motivation and Context
Used for debugging

## Tests performed
This code has been running on BW for the past few months without problems.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- My code follows the code style of this project as found in the **CONTRIBUTING** document.
- All new and existing tests passed.
