### PR TITLE
Do not allow style failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
         - TEST_SUITE=style
         - TEST_SUITE=build CACHE_NAME=build
 
-matrix:
-    allow_failures:
-        - env: TEST_SUITE=style
-
 # Add dependency directories to the Travis cache
 cache:
     directories:


### PR DESCRIPTION
Do not allow style failures in travis.

## Description
Do not allow style failures in travis.

## Motivation and Context
 The current code passes the style checks so there is no need to allow fails.

## Tests performed
Ran travis.
