### PR TITLE
Travis build scripts now check for phpcs ERRORs

### DIFF
--- a/.travis.build.sh
+++ b/.travis.build.sh
@@ -108,7 +108,7 @@ if [ "$TEST_SUITE" = "syntax" ]; then
     done
 elif [ "$TEST_SUITE" = "style" ]; then
     for file in "${php_files_changed[@]}"; do
-        phpcs "$file"
+        phpcs "$file" || phpcs -n "$file" > /dev/null 2>&1
         if [ $? != 0 ]; then
             build_exit_value=2
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
         - TEST_SUITE=style
         - TEST_SUITE=build CACHE_NAME=build
 
-matrix:
-    allow_failures:
-        - env: TEST_SUITE=style
-
 # Add dependency directories to the Travis cache
 cache:
     directories:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
 <ruleset name="XDMoD Standard">
   <description>XDMoD PHP coding standard</description>
+  <exclude-pattern>*/template.*.php</exclude-pattern>
   <rule ref="PSR1"/>
   <rule ref="PSR2"/>
+  <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+    <type>warning</type>
+  </rule>
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="256"/>
+      <property name="absoluteLineLimit" value="0"/>
+    </properties>
+  </rule>
 </ruleset>


### PR DESCRIPTION
Previously the phpcs was run but any errors or warnings were ignored.
Now travis build will fail if phpcs detects any errors.

## Description
- Travis checks return value of phpcs -n
-  phpcs with warnings is also run so that the (non-fatal) warnings appear in the logs. Needless to say I'll be asking folks to get rid of warnings in new code at code review time.
- two phpcs rules were modified
  - The max line length is now set to 256.
  - Lack of namespace is a warning rather than an error.

The template.*.php files are excluded from the syntax checking because they are not php files.

## Motivation and Context
Try to improve the overall code quality.

## Tests performed
Ran changes through travis.
