### PR TITLE
Fix job viewer load error with version 4 timeseries documents.

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/JobTimeseries.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobTimeseries.php
@@ -95,6 +95,11 @@ class JobTimeseries
         if( !isset( $this->_doc[$metric] ) ) {
             return null;
         }
+
+        if (isset($this->_doc[$metric]['error'])) {
+            return null;
+        }
+
         $ret = array( "series" => array() );
 
         if( $nodeidx === null )

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,22 @@
                     "installer-name": "jsPlumb"
                 }
             }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ubccr/xdmod-test-artifacts",
+                "version": "master",
+                "dist": {
+                    "url": "https://github.com/ubccr/xdmod-test-artifacts/archive/master.zip",
+                    "type": "zip",
+                    "reference": "master"
+                },  
+                "autoload": {
+                    "classmap": ["."]
+                }
+            }   
+        
         }
     ],
     "extra": {
@@ -38,6 +54,7 @@
         }
     },
     "require-dev": {
+        "ubccr/xdmod-test-artifacts": "dev-master",
         "squizlabs/php_codesniffer": "2.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -214,11 +214,29 @@
                 "standards"
             ],
             "time": "2016-04-03 22:58:34"
+        },
+        {
+            "name": "ubccr/xdmod-test-artifacts",
+            "version": "master",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/ubccr/xdmod-test-artifacts/archive/master.zip",
+                "reference": "master",
+                "shasum": null
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "."
+                ]
+            }
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "ubccr/xdmod-test-artifacts": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,7 +28,6 @@ spl_autoload_register(
             . str_replace('\\', '/', $className)
             . '.php';
 
-        error_log("Checking ".$classPath);
         if (is_readable($classPath)) {
             return require_once $classPath;
         } else {

--- a/tests/lib/DataWarehouse/Query/SUPREMM/JobTimeseriesTest.php
+++ b/tests/lib/DataWarehouse/Query/SUPREMM/JobTimeseriesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DataWarehouse\Query\SUPREMM;
+
+class JobTimeseriesTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_PATH = "../vendor/ubccr/xdmod-test-artifacts/xdmod-supremm/summaries/";
+
+    /**
+     * @dataProvider validDataProvider
+     */
+    public function testGetMainData($inputdoc) {
+
+        $timeseries = new \DataWarehouse\Query\SUPREMM\JobTimeseries($inputdoc);
+
+        $cpuuser = $timeseries->get('cpuuser', null, null);
+
+        $this->assertArrayHasKey('schema', $cpuuser);
+        $this->assertArrayHasKey('series', $cpuuser);
+        
+    }
+
+    /**
+     * @dataProvider validDataProvider
+     */
+    public function testGetNodeData($inputdoc) {
+
+        $timeseries = new \DataWarehouse\Query\SUPREMM\JobTimeseries($inputdoc);
+
+        $cpuuser = $timeseries->get('cpuuser', 0, null);
+
+        $this->assertArrayHasKey('schema', $cpuuser);
+        $this->assertArrayHasKey('series', $cpuuser);
+        
+    }
+
+    /**
+     * @dataProvider missingDataProvider
+     */
+    public function testProcessMissing($inputdoc) {
+
+        $timeseries = new \DataWarehouse\Query\SUPREMM\JobTimeseries($inputdoc);
+
+        $cpuuser = $timeseries->get('cpuuser', null, null);
+
+        $this->assertNull($cpuuser);
+    }
+
+    private function getDataFiles($datafiles) {
+        $schemafile = "timeseries-4.json";
+
+        $schema = json_decode(file_get_contents(self::TEST_ARTIFACT_PATH . $schemafile), true);
+
+        $output = array();
+
+        foreach($datafiles as $datafile) {
+            $data = json_decode(file_get_contents(self::TEST_ARTIFACT_PATH . $datafile), true);
+            $data['schema'] = $schema;
+
+            $output[] = array($data);
+        }
+
+        return $output;
+    }
+
+    /*
+     * A data provider for valid data
+     */
+    public function validDataProvider() {
+        return $this->getDataFiles(
+            array(
+                "4454065-1441406017.json",
+                "1000000-1371867036.json"
+            )
+        );
+    }
+
+    /*
+     * A data provider for data with missing metrics
+     */
+    public function missingDataProvider() {
+        return $this->getDataFiles(
+            array(
+                "4229255-1438628743.json"
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Description
- The timeseries docs allow individual metrics to be absent and report
and error code. The php code did not check for the error code and incorrectly
assumed that the data was present.
- Added unit test to confirm that the code change worked.

Note also added the xdmod-test-artifacts as a dependency for the test data needed
by the unit test.

Also removed a spurious debug print statement from the test harness.

## Motivation and Context
Bug fix

## Tests performed
Ran unit tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
