### PR TITLE
Travis: Cache npm cache directory instead of node_modules directories

### DIFF
--- a/.travis.build.sh
+++ b/.travis.build.sh
@@ -62,20 +62,9 @@ fi
 
 # Build tests require the corresponding version of Open XDMoD.
 if [ "$TEST_SUITE" = "build" ] || [ "$TEST_SUITE" = "unit" ]; then
-    # If present, move Travis cache dirs out of the way.
-    xdmod_cache_exists="false"; [ -e ../xdmod ] && xdmod_cache_exists="true"
-    if "$xdmod_cache_exists"; then
-        mv ../xdmod ../xdmod-cache
-    fi
-
     xdmod_branch="$TRAVIS_BRANCH"
     echo "Cloning Open XDMoD branch '$xdmod_branch'"
     git clone --depth=1 --branch="$xdmod_branch" https://github.com/ubccr/xdmod.git ../xdmod
-
-    # If present, move Travis cache dirs back in.
-    if "$xdmod_cache_exists"; then
-        mv ../xdmod-cache/etl/js/node_modules ../xdmod/etl/js/node_modules
-    fi
 
     pushd ../xdmod
     . .travis.install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ env:
 # Add dependency directories to the Travis cache
 cache:
     directories:
-        - node_modules
-        - ../xdmod/etl/js/node_modules
+        - $HOME/.npm
         - $HOME/.composer/cache
         - /tmp/pear/cache
 


### PR DESCRIPTION
## Description
This pull request modifies the behavior of the Travis cache mechanism to cache npm's global cache directory instead of `node_modules` directories.

If accepted, similar pull requests will be opened for other XDMoD repos.

## Motivation and Context
Unexpected behavior is more likely to occur when copying and updating an old `node_modules` directory than when creating a fresh `node_modules` directory, as evidenced by the Travis errors encountered with #28. This change ensures that fresh `node_modules` directories are created each run while still allowing us to benefit from the Travis cache mechanism.

## Tests Performed
Ran test runs of Travis with the changes and verified that they completed successfully.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
