### PR TITLE
Style: Removed ESLint rule prohibiting for...in statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,6 +76,21 @@
     ],
     "no-continue": "off",
     "no-plusplus": "off",
-    "no-prototype-builtins": "off"
+    "no-prototype-builtins": "off",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "ForOfStatement",
+        "message": "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations."
+      },
+      {
+        "selector": "LabeledStatement",
+        "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
+      },
+      {
+        "selector": "WithStatement",
+        "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description
This pull request removes the ESLint rule prohibiting `for...in` statements in JavaScript code.

If accepted, similar pull requests will be opened for other XDMoD repos.

## Motivation and Context
Use of `for...in` with proper precautions (e.g. checking for prototype properties, not using it on objects with deep prototype chains where performance matters) results in code that is easier to write and read than alternative methods.

## Tests Performed
Verified that ESLint still worked with the new config file.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
