### PR TITLE
Fix error when processing job summaries that are marked as error.

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/JobMetadata.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobMetadata.php
@@ -99,6 +99,9 @@ class JobMetadata
             if (is_array($value) && array_key_exists('*', $value)) {
                 if (isset($merged[$key]) && is_array($merged[$key])) {
                     foreach ($merged[$key] as $mkey => $mvalue) {
+                        if ($mkey === "error") {
+                            break;
+                        }
                         $merged[$key][$mkey] = $this->arrayMergeRecursiveWildcard($mvalue, $value['*']);
                     }
                 }

--- a/composer.json
+++ b/composer.json
@@ -25,20 +25,8 @@
             }
         },
         {
-            "type": "package",
-            "package": {
-                "name": "ubccr/xdmod-test-artifacts",
-                "version": "master",
-                "dist": {
-                    "url": "https://github.com/ubccr/xdmod-test-artifacts/archive/master.zip",
-                    "type": "zip",
-                    "reference": "master"
-                },  
-                "autoload": {
-                    "classmap": ["."]
-                }
-            }   
-        
+            "type": "vcs",
+            "url": "https://github.com/ubccr/xdmod-test-artifacts.git"
         }
     ],
     "extra": {
@@ -54,7 +42,7 @@
         }
     },
     "require-dev": {
-        "ubccr/xdmod-test-artifacts": "dev-master",
+        "ubccr/xdmod-test-artifacts": "@dev",
         "squizlabs/php_codesniffer": "2.8.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e60949b340a2e6637420b54fea3906e4",
+    "content-hash": "d44a6743efe4cb009de232fbe31567d2",
     "packages": [
         {
             "name": "composer/installers",
@@ -216,19 +216,25 @@
         },
         {
             "name": "ubccr/xdmod-test-artifacts",
-            "version": "master",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ubccr/xdmod-test-artifacts.git",
+                "reference": "fe17a3f7b09febaec33a8e0ccbfe38fb8605d039"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/ubccr/xdmod-test-artifacts/archive/master.zip",
-                "reference": "master",
-                "shasum": null
+                "url": "https://api.github.com/repos/ubccr/xdmod-test-artifacts/zipball/fe17a3f7b09febaec33a8e0ccbfe38fb8605d039",
+                "reference": "fe17a3f7b09febaec33a8e0ccbfe38fb8605d039",
+                "shasum": ""
             },
             "type": "library",
-            "autoload": {
-                "classmap": [
-                    "."
-                ]
-            }
+            "description": "Test artifacts for XDMoD and XDMoD submodules",
+            "support": {
+                "source": "https://github.com/ubccr/xdmod-test-artifacts/tree/master",
+                "issues": "https://github.com/ubccr/xdmod-test-artifacts/issues"
+            },
+            "time": "2017-04-19T19:08:38+00:00"
         }
     ],
     "aliases": [],

--- a/tests/unit_tests/bootstrap.php
+++ b/tests/unit_tests/bootstrap.php
@@ -8,7 +8,7 @@ spl_autoload_register(
         $classPath
             = $dir
             . '/lib/'
-            . str_replace('_', '/', $className)
+            . str_replace('\\', '/', $className)
             . '.php';
 
         if (is_readable($classPath)) {
@@ -35,6 +35,23 @@ spl_autoload_register(
         }
     }
 );
+
+// Autoloader for XDMoD test classes
+spl_autoload_register(
+    function ($className) use ($dir) {
+        $classPath
+            = __DIR__ . '/../../../xdmod/open_xdmod/modules/xdmod/tests/lib/'
+            . str_replace('\\', '/', $className)
+            . '.php';
+
+        if (is_readable($classPath)) {
+            return require_once $classPath;
+        } else {
+            return false;
+        }
+    }
+);
+
 
 // Autoloader for XDMoD classes.
 require_once __DIR__ . '/../../../xdmod/configuration/linker.php';

--- a/tests/unit_tests/lib/DataWarehouse/Query/SUPREMM/JobMetadataTest.php
+++ b/tests/unit_tests/lib/DataWarehouse/Query/SUPREMM/JobMetadataTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DataWarehouse\Query\SUPREMM;
+
+class JobMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_PATH = "../../vendor/ubccr/xdmod-test-artifacts/xdmod-supremm/summaries/";
+
+    /**
+     * @dataProvider arrayMergeTestdata
+     */
+    public function testArrayMerge($left, $right, $expected)
+    {
+        $jobmd = new \TestHelpers\mock\JobMetadataWorkaround();
+
+        $arrayMergeFn = \TestHelpers\TestHelper::unlockMethod($jobmd, 'arrayMergeRecursiveWildcard');
+        $result = $arrayMergeFn->invoke($jobmd, $left, $right);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function arrayMergeTestdata()
+    {
+        $output = array();
+
+        $left = array(
+            "one" => array("data" => 1),
+            "two" => array("data" => 2),
+            "three" => array("data" => 3)
+        );
+
+        $right = array(
+            "one" => array("doc" => 1),
+            "two" => array("doc" => 2),
+            "three" => array("doc" => 3)
+        );
+
+        $expected = array(
+            "one" => array("data" => 1, "doc" => 1),
+            "two" => array("data" => 2, "doc" => 2),
+            "three" => array("data" => 3, "doc" => 3)
+        );
+
+        $output[] = array($left, $right, $expected);
+
+        $left = array(
+            "metric" => array(
+                "device1" => array("data" => 1),
+                "device2" => array("data" => 2)
+            )
+        );
+
+        $right = array(
+            "metric" => array(
+                "*" => array("doc" => 1)
+            )
+        );
+
+        $expected = array(
+            "metric" => array(
+                "device1" => array("data" => 1, "doc" => 1),
+                "device2" => array("data" => 2, "doc" => 1)
+            )
+        );
+
+        $output[] = array($left, $right, $expected);
+
+        $left = json_decode(file_get_contents(self::TEST_ARTIFACT_PATH . '4824787-1451650405-gpu.json'), true);
+
+        $schema = json_decode(file_get_contents(self::TEST_ARTIFACT_PATH . 'summary-1.0.7-gpu.json'), true);
+        $right = $schema['definitions'];
+        $expected = $left;
+
+        $output[] = array($left, $right, $expected);
+
+        return $output;
+
+    }
+}

--- a/tests/unit_tests/lib/TestHelpers/mock/JobMetadataWorkaround.php
+++ b/tests/unit_tests/lib/TestHelpers/mock/JobMetadataWorkaround.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace TestHelpers\mock;
+
+/* Unfortunately, the JobMetadata class was not designed to be testable
+* so this workaround is a necessary evil.
+*/
+class JobMetadataWorkaround extends \DataWarehouse\Query\SUPREMM\JobMetadata
+{
+    public function __construct() {
+    }
+}


### PR DESCRIPTION
## Description
Fix php error when processing job summaries that had a wildcard schema entry, but the
corresponding summary entry was marked as error.

Also add unit tests for the code change. Now have 100% code coverage for
the function.

## Motivation and Context
Bug fix

## Tests performed
Created and ran unit tests.

## Types of changes
-  Bug fix (non-breaking change which fixes an issue)
