### PR TITLE
Added SUPREMM Modules files to build.json

### DIFF
--- a/build.json
+++ b/build.json
@@ -73,7 +73,8 @@
             "configuration/internal_dashboard.d/supremm.json": "internal_dashboard.d/supremm.json",
             "configuration/rawstatisticsconfig.json": "",
             "configuration/supremmconfig.json": "",
-            "configuration/aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json": "aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json"
+            "configuration/aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json": "aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json",
+            "configuration/modules.d/supremm.json": "modules.d/supremm.json"
         }
     }
 }

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -48,6 +48,7 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xdmod/rawstatisticsconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/supremmconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json
+%config(noreplace) %{_sysconfdir}/modules.d/supremm.json
 
 %changelog
 * Thu May 11 2017 Jeffrey T. Palmer <jtpalmer@buffalo.edu> 6.6.0-1.0

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -41,6 +41,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/xdmod/
 %{_datadir}/xdmod/
 %{_docdir}/%{name}-%{version}__PRERELEASE__/
+%{_sysconfdir}/modules.d/supremm.json
 
 %config(noreplace) %{_datadir}/xdmod/etl/js/config/supremm/etl.profile.js
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/supremm.ini
@@ -48,7 +49,6 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xdmod/rawstatisticsconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/supremmconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json
-%config(noreplace) %{_sysconfdir}/modules.d/supremm.json
 
 %changelog
 * Thu May 11 2017 Jeffrey T. Palmer <jtpalmer@buffalo.edu> 6.6.0-1.0

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -41,11 +41,15 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/xdmod/
 %{_datadir}/xdmod/
 %{_docdir}/%{name}-%{version}__PRERELEASE__/
-%{_sysconfdir}/modules.d/supremm.json
+%{_sysconfdir}/xdmod/modules.d/supremm.json
 
 %config(noreplace) %{_datadir}/xdmod/etl/js/config/supremm/etl.profile.js
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/supremm.ini
-%config(noreplace) %{_sysconfdir}/xdmod/*.d/supremm*.json
+%config(noreplace) %{_sysconfdir}/xdmod/datawarehouse.d/supremm*.json
+%config(noreplace) %{_sysconfdir}/xdmod/internal_dashboard.d/supremm*.json
+%config(noreplace) %{_sysconfdir}/xdmod/roles.d/supremm*.json
+%config(noreplace) %{_sysconfdir}/xdmod/setup.d/supremm*.json
+%config(noreplace) %{_sysconfdir}/xdmod/rest.d/supremm*.json
 %config(noreplace) %{_sysconfdir}/xdmod/rawstatisticsconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/supremmconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/aggregation_meta/modw_aggregates.supremmfact_aggregation_meta.json


### PR DESCRIPTION
- Added modules.d/supremm.json to the file_maps section of build.json

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the modules.d/supremm.json file to build.json so that it is included in the packaged module.

## Motivation and Context
Needed to pipe through the new modules.d/\<module\>.json file through to the package / final installed source. 

## Tests performed
Manually tested: 
  - Made changes to build.json
  - Executed: <xdmod_dir>/open_xdmod/build_package.php --module supremm --skip-assets --verbose
  - cd <xdmod_dir>/open_xdmod/build
  - tar xvzf xdmod-supremm-6.7.0.tar.gz 
  - ls -alh xdmod-supremm/configuration/modules.d
    - ensure that: supremm.json is present
  - cat xdmod-supremm/configuration/modules.d/supremm.json
    - ensure that the file is a valid json file and contains the correct information.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
