### PR TITLE
Ensure JobDataset provides the required data fields.

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
@@ -184,6 +184,7 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
         } elseif ($stat == "internal") {
             $this->addField(new TableField($dataTable, "resource_id"));
             $this->addField(new TableField($dataTable, "local_job_id"));
+            $this->addField(new TableField($dataTable, "start_time_ts"));
             $this->addField(new TableField($dataTable, "end_time_ts"));
             $this->addField(new TableField($dataTable, "cpu_user"));
             $this->addField(new TableField($dataTable, "catastrophe"));
@@ -193,6 +194,7 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
             $this->addTable($rf);
             $this->addWhereCondition(new WhereCondition(new TableField($dataTable, 'resource_id'), '=', new TableField($rf, 'id')));
             $this->addField(new TableField($rf, 'timezone'));
+            $this->addField(new TableField($rf, 'code', 'resource'));
 
         } elseif ($stat == "peers") {
             $jp = new Table(new Schema("modw_supremm"), "job_peers", "jp");
@@ -202,6 +204,8 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
             $this->addTable($jf);
             $this->addWhereCondition(new WhereCondition(new TableField($jp, "other_job_id"), '=', new TableField($jf, "_id")));
             $this->addField(new TableField($jf, "local_job_id"));
+            $this->addField(new TableField($jf, "start_time_ts"));
+            $this->addField(new TableField($jf, "end_time_ts"));
 
             $rt = new Table(new Schema("modw"), "resourcefact", "rf");
             $this->addTable($rt);
@@ -212,6 +216,14 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
             $this->addTable($pt);
             $this->addWhereCondition(new WhereCondition(new TableField($jf, "person_id"), '=', new TableField($pt, "id")));
             $this->addField(new TableField($pt, "long_name", "name"));
+
+            $this->addOrder(
+                new \DataWarehouse\Query\Model\OrderBy(
+                    new TableField($jf, 'start_time_ts'),
+                    'asc',
+                    'start_time_ts'
+                )
+            );
         } else {
             // TODO This code is very similar to the code in ./classes/DataWarehouse/Query/SUPREMM/RawData.php ~ line 58
             // make this more common


### PR DESCRIPTION
The job peers framework code needs the job start and end times
for all jobs. This change ensures that these values are pulled from the
database.

Also add an order by clause to the peers query so that jobs are returned
in time order.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
