### PR TITLE
Enable dataflow diagram by default.

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
+++ b/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
@@ -27,6 +27,13 @@ class SupremmDbInterface {
 
     }
 
+    /** get the list of configured resources
+     * @return array list of resource ids of the configured resources
+     */
+    public function getResources() {
+        return array_keys($this->resource_rmap);
+    }
+
     public function getResourceConfig($resource_id) {
 
         if( ! array_key_exists($resource_id, $this->resource_rmap) ) {

--- a/configuration/internal_dashboard.d/supremm.json
+++ b/configuration/internal_dashboard.d/supremm.json
@@ -1,4 +1,13 @@
 {
+    "+menu": [
+        {
+            "class": "XDMoD.Dashboard.FramePanel",
+            "config": {
+                "title": "SUPReMM Dataflow",
+                "url": "/internal_dashboard/supremm/stats.php"
+            }
+        }
+    ],
     "+logs": [
         {
             "ident": "SUPREMM",

--- a/html/internal_dashboard/supremm/css/style.css
+++ b/html/internal_dashboard/supremm/css/style.css
@@ -56,26 +56,17 @@ td.zeroer
     clear: both;
 }
 
-.sqldatastore {
-    background-color: #95ed64;
-    border-bottom-color: #346789;
-    border-bottom-left-radius: 5.76667px;
-    border-bottom-right-radius: 5.76667px;
+.datastore
+{
+    border-bottom-color: black;
     border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-left-color: #346789;
-    border-left-style: solid;
-    border-left-width: 1px;
-    border-right-color: #346789;
-    border-right-style: solid;
-    border-right-width: 1px;
-    border-top-color: #346789;
-    border-top-left-radius: 5.76667px;
-    border-top-right-radius: 5.76667px;
+    border-bottom-width: 2px;
+    border-top-color: black;
     border-top-style: solid;
-    border-top-width: 1px;
+    border-top-width: 2px;
     box-shadow: #AAA 2px 2px 19px 0px;
     color: #000;
+    height: 8em;
     opacity: 0.8;
     padding-bottom: 5.76667px;
     padding-left: 5.76667px;
@@ -84,100 +75,61 @@ td.zeroer
     transition-delay: 0s;
     transition-duration: 0.15s;
     transition-propertybox-shadowtransition-timing-function: cubic-bezier(0.42, 0, 1, 1);
-    height: 5em;
     width: 15em;
     -moz-border-bottom-colors: none;
     -moz-border-left-colors: none;
     -moz-border-right-colors: none;
     -moz-border-top-colors: none;
     position: absolute;
+}
+
+.datasource
+{
+    border: thin solid black;
+    box-shadow: #AAA 2px 2px 19px 0px;
+    width: 150px;
+    height: 4em;
+    display: table;
+    position: absolute;
+}
+
+.process
+{
+    border: thin solid black;
+    border-radius: 50%;
+    width: 12em;
+    height: 6em;
+    box-shadow: #AAA 2px 2px 19px 0px;
+    display: table;
+    position: absolute;
+}
+
+.sqldatastore {
+    background-color: #95ed64;
 }
 
 .mongodatastore
 {
     background-color: #deb0c4;
-    border-bottom-color: #346789;
-    border-bottom-left-radius: 5.76667px;
-    border-bottom-right-radius: 5.76667px;
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-left-color: #346789;
-    border-left-style: solid;
-    border-left-width: 1px;
-    border-right-color: #346789;
-    border-right-style: solid;
-    border-right-width: 1px;
-    border-top-color: #346789;
-    border-top-left-radius: 5.76667px;
-    border-top-right-radius: 5.76667px;
-    border-top-style: solid;
-    border-top-width: 1px;
-    box-shadow: #AAA 2px 2px 19px 0px;
-    color: #000;
-    height: 5em;
-    width: 15em;
-    opacity: 0.8;
-    padding-bottom: 5.76667px;
-    padding-left: 5.76667px;
-    padding-right: 5.76667px;
-    padding-top: 5.76667px;
-    transition-delay: 0s;
-    transition-duration: 0.15s;
-    transition-propertybox-shadowtransition-timing-function: cubic-bezier(0.42, 0, 1, 1);
-    -moz-border-bottom-colors: none;
-    -moz-border-left-colors: none;
-    -moz-border-right-colors: none;
-    -moz-border-top-colors: none;
-    position: absolute;
 }
 
 .filedatastore {
     background-color: #b0c4de;
-    border-bottom-color: #346789;
-    border-bottom-left-radius: 5.76667px;
-    border-bottom-right-radius: 5.76667px;
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-left-color: #346789;
-    border-left-style: solid;
-    border-left-width: 1px;
-    border-right-color: #346789;
-    border-right-style: solid;
-    border-right-width: 1px;
-    border-top-color: #346789;
-    border-top-left-radius: 5.76667px;
-    border-top-right-radius: 5.76667px;
-    border-top-style: solid;
-    border-top-width: 1px;
-    box-shadow: #AAA 2px 2px 19px 0px;
-    color: #000;
-    height: 80px;
-    opacity: 0.8;
-    padding-bottom: 5.76667px;
-    padding-left: 5.76667px;
-    padding-right: 5.76667px;
-    padding-top: 5.76667px;
-    transition-delay: 0s;
-    transition-duration: 0.15s;
-    transition-propertybox-shadowtransition-timing-function: cubic-bezier(0.42, 0, 1, 1);
-    width: 80px;
-    -moz-border-bottom-colors: none;
-    -moz-border-left-colors: none;
-    -moz-border-right-colors: none;
-    -moz-border-top-colors: none;
-    position: absolute;
 }
 
 .statsbox {
     font-size: 80%;
 }
 
-#remote_machine { top: 3em; left:  7em; }
-#local_mirror   { top: 3em; left: 24em; }
-#accountfact    { top:13em; left: 37em; height: 8em; }
-#mongo          { top:26em; left: 30em; height: 8em; }
-#jobfact        { top:23em; left: 54em; height: 7em; }
-#aggregates     { top:33em; left: 54em; }
+#pcpdatasource  { top: 2em; left: 2em; }
+#resdatasource  { top: 9em; left: 2em; }
+#local_mirror   { top: 2em; left: 24em; }
+#summarization_scripts { top: 4.5em; left: 56.9em; }
+#mongo          { top: 15em; left: 55em; height: 8em; }
+#accountfact    { top: 15em; left: 23em; height: 8em; width: 17em; }
+#etl_process    { top: 29em; left: 47em; }
+#jobfact        { top: 28em; left: 24em; height: 7em; }
+#aggregates     { top: 28em; left: 4em; height: 7em; }
 
 #flowchart {
     border: thin solid black;
@@ -207,11 +159,15 @@ td.zeroer
 
 #key {
     position: absolute;
-    top: 36em;
-    left: 1em;
+    bottom: 0;
+    right: 1ex;
 }
 
-
+span.centered {
+  text-align: center;
+	vertical-align: middle;
+  display: table-cell;
+}
 .filekey {
     border: thin solid black;
     background-color: #b0c4de;

--- a/html/internal_dashboard/supremm/js/stats.js
+++ b/html/internal_dashboard/supremm/js/stats.js
@@ -1,110 +1,150 @@
 
-            Ext.ns('XDMoD');
-            jsPlumb.ready(function() {
+Ext.ns('XDMoD', 'XDMoD.SupremmDataFlow');
 
-                var common = {
-                      endpoints:["Blank", "Blank" ],
-                      overlays: [ [ "PlainArrow", { location: 1.0 } ] ],
-                      paintStyle: { strokeStyle:"#216477", lineWidth:5 }
-                    };
+XDMoD.SupremmDataFlow = {
+    resource_map: {},
+    loadData: function (selector, endPoint, resourceId) {
+        $(selector).html('<img src="/gui/images/loading.gif"></img>Loading');
 
-                jsPlumb.setContainer($("#flowchart"));
-
-                jsPlumb.connect({
-                      source:$("#remote_machine"),
-                      target: $("#local_mirror"),
-                      connector: "Straight",
-                      anchor: "AutoDefault"
-                  }, common);
-
-                jsPlumb.connect({
-                      source:$("#local_mirror"),
-                      target: $("#accountfact"),
-                      anchors:[ "BottomCenter", "TopCenter" ]
-                  }, common);
-
-                jsPlumb.connect({
-                      source:$("#local_mirror"),
-                      target: $("#mongo"),
-                      anchors:[ "BottomCenter", "TopCenter" ]
-                  }, common);
-
-                jsPlumb.connect({
-                      source:$("#accountfact"),
-                      target: $("#mongo"),
-                      anchors:[ "BottomCenter", "TopCenter" ]
-                  }, common);
-
-                jsPlumb.connect({
-                      source:$("#mongo"),
-                      target: $("#jobfact"),
-                      anchor: "AutoDefault"
-                  }, common);
-
-                jsPlumb.connect({
-                      source:$("#jobfact"),
-                      target: $("#aggregates"),
-                      connector: "Straight",
-                      anchor: "AutoDefault"
-                  }, common);
-
-            });
-
-            var resource_map = {};
-
-            var loadstats = function(resource_id) {
-
-                var loading = "<img src=\"/gui/images/loading.gif\"></img>Loading";
-
-                $("#accountfact_content").html(loading);
-                $("#mongo_content").html(loading);
-                $("#jobfact_content").html(loading);
-                $("#aggregates_content").html(loading);
-
-                var print_list = function(data, selector) {
-                    var h = "<ul>";
-                    var d = data.data;
-                    for (var k in d) {
-                        if (d.hasOwnProperty(k)) {
-                            h = h + '<li>' + k + ': ' + d[k] + '</li>';
-                        }
+        $.getJSON(XDMoD.REST.url + '/supremm_dataflow/dbstats',
+            {
+                token: XDMoD.REST.token,
+                resource_id: resourceId,
+                db_id: endPoint
+            },
+            function (data) {
+                var html = '<ul>';
+                var d = data.data.data;
+                for (var k in d) {
+                    if (d.hasOwnProperty(k)) {
+                        html += '<li>' + k + ': ' + d[k] + '</li>';
                     }
-                    h = h + "</ul>";
-                    $(selector).html(h);
-                };
+                }
+                html += '</ul>';
+                $(selector).html(html);
+            }
+        ).fail(function (jqXHR, textStatus, errorThrown) {
+            var html = '<b>Error<b>';
+            if (jqXHR.responseJSON) {
+                if (jqXHR.responseJSON.message) {
+                    html += '<br />' + jqXHR.responseJSON.message;
+                }
+            } else {
+                html += textStatus + ' ' + errorThrown;
+            }
+            $(selector).html(html);
+        });
+    },
+    loadAllStats: function (resourceId) {
+        $('#pagetitle').text('Data flow information for ' + XDMoD.SupremmDataFlow.resource_map[resourceId]);
+        $('#flowchart').show(500);
 
-                $.getJSON(XDMoD.REST.url + '/supremm_dataflow/dbstats', { token: XDMoD.REST.token, resource_id: resource_id, db_id: 'accountdb' },
-                        function(data) { print_list(data.data, "#accountfact_content"); });
-                $.getJSON(XDMoD.REST.url + '/supremm_dataflow/dbstats', { token: XDMoD.REST.token, resource_id: resource_id, db_id: 'summarydb' },
-                        function(data) { print_list(data.data, "#mongo_content"); });
-                $.getJSON(XDMoD.REST.url + '/supremm_dataflow/dbstats', { token: XDMoD.REST.token, resource_id: resource_id, db_id: 'jobfact' },
-                        function(data) { print_list(data.data, "#jobfact_content"); });
-                $.getJSON(XDMoD.REST.url + '/supremm_dataflow/dbstats', { token: XDMoD.REST.token, resource_id: resource_id, db_id: 'aggregates' },
-                        function(data) { print_list(data.data, "#aggregates_content"); });
+        XDMoD.SupremmDataFlow.loadData('#local_mirror_content', 'nodearchives', resourceId);
+        XDMoD.SupremmDataFlow.loadData('#accountfact_content', 'accountfact', resourceId);
+        XDMoD.SupremmDataFlow.loadData('#mongo_content', 'summarydb', resourceId);
+        XDMoD.SupremmDataFlow.loadData('#jobfact_content', 'jobfact', resourceId);
+        XDMoD.SupremmDataFlow.loadData('#aggregates_content', 'aggregates', resourceId);
+    }
+};
 
-                $("#pagetitle").text("Data flow information for " + resource_map[resource_id] );
-            };
+jsPlumb.ready(function () {
+    var common = {
+        endpoints: ['Blank', 'Blank'],
+        overlays: [['PlainArrow', { location: 1.0 }]],
+        connector: 'Flowchart',
+        paintStyle: { strokeStyle: '#216477', lineWidth: 5 }
+    };
 
-            $(document).ready(function(){
+    jsPlumb.setContainer($('#flowchart'));
 
-                $( "#resourceform" ).submit(function(evt) {
-                    evt.preventDefault();
-                    loadstats( $("#resourceselect").val() );
-                });
+    jsPlumb.connect({
+        source: $('#pcpdatasource'),
+        target: $('#local_mirror'),
+        anchors: ['Right', 'Left']
+    }, common);
 
-                $.getJSON(XDMoD.REST.url + '/supremm_dataflow/resources', { token: XDMoD.REST.token }, function (data) {
-                    var select = document.getElementById("resourceselect");
+    jsPlumb.connect({
+        source: $('#local_mirror'),
+        target: $('#summarization_scripts'),
+        anchors: ['Right', 'Top']
+    }, common);
 
-                    for (var i = 0; i < data.data.length ; i++) {
-                        var element = data.data[i];
-                        var tmp = document.createElement("option");
-                        tmp.text = element.name;
-                        tmp.value = element.id;
-                        select.appendChild(tmp);
-                        resource_map[element.id] = element.name;
-                    }
+    jsPlumb.connect({
+        source: $('#accountfact'),
+        target: $('#summarization_scripts'),
+        anchors: ['Right', 'Left']
+    }, common);
 
-                    $( "#resourceform" ).submit();
-                });
+    jsPlumb.connect({
+        source: $('#summarization_scripts'),
+        target: $('#mongo'),
+        anchors: ['Bottom', 'Top']
+    }, common);
 
-            });
+    jsPlumb.connect({
+        source: $('#accountfact'),
+        target: $('#etl_process'),
+        anchors: ['Right', 'TopCenter']
+    }, common);
+
+    jsPlumb.connect({
+        source: $('#mongo'),
+        target: $('#etl_process'),
+        anchor: ['Right', 'Right']
+    }, common);
+
+    jsPlumb.connect({
+        source: $('#etl_process'),
+        target: $('#jobfact'),
+        anchor: ['Left', 'Right']
+    }, common);
+
+    jsPlumb.connect({
+        source: $('#resdatasource'),
+        target: $('#accountfact'),
+        anchor: ['Right', 'Left']
+    }, common);
+
+    jsPlumb.connect({
+        source: $('#jobfact'),
+        target: $('#aggregates'),
+        connector: 'Straight',
+        anchor: 'AutoDefault'
+    }, common);
+});
+
+$(document).ready(function () {
+    $('#resourceform').hide();
+    $('#flowchart').hide();
+    $('#resourceform').submit(function (evt) {
+        evt.preventDefault();
+        $('#flowchart').hide();
+        XDMoD.SupremmDataFlow.loadAllStats($('#resourceselect').val());
+    });
+
+    $.getJSON(XDMoD.REST.url + '/supremm_dataflow/resources', { token: XDMoD.REST.token }, function (data) {
+        var select = document.getElementById('resourceselect');
+
+        for (var i = 0; i < data.data.length; i++) {
+            var element = data.data[i];
+            var tmp = document.createElement('option');
+            tmp.text = element.name;
+            tmp.value = element.id;
+            select.appendChild(tmp);
+            XDMoD.SupremmDataFlow.resource_map[element.id] = element.name;
+        }
+        $('#loading').hide();
+        $('#resourceform').show(500);
+        $('#resourceform').submit();
+    }).fail(function (jqXHR, textStatus, errorThrown) {
+        var html = '<b>Error</b><br />';
+        if (jqXHR.responseJSON) {
+            if (jqXHR.responseJSON.message) {
+                html += jqXHR.responseJSON.message;
+            }
+        } else {
+            html += textStatus + ' ' + errorThrown;
+        }
+        $('#loading').html(html);
+    });
+});

--- a/html/internal_dashboard/supremm/stats.php
+++ b/html/internal_dashboard/supremm/stats.php
@@ -22,6 +22,7 @@ require_once 'user_check.php';
         <link rel="stylesheet" href="css/style.css" type="text/css" />
     </head>
     <body>
+        <div id="loading"><img src="/gui/images/loading.gif"></img>Loading</div>
         <div>
             <form id="resourceform" action="." method="get">
                 <select name="resourceid" id="resourceselect"> </select>
@@ -30,38 +31,46 @@ require_once 'user_check.php';
         </div>
         <h1 id="pagetitle"></h1>
         <div id="flowchart">
-            <div id="remote_machine" class="filedatastore">
-                Remote Machine
-                <div id="remote_machine_content" class="statsbox"></div>
-            </div>
-            <div id="local_mirror" class="filedatastore">
-                Local mirror
+            <div id="local_mirror" class="filedatastore datastore">
+                PCP archive files
                 <div id="local_mirror_content" class="statsbox"></div>
             </div>
-            <div id="accountfact" class="sqldatastore">
-                Accounting data cache
+            <div id="accountfact" class="sqldatastore datastore">
+                Accounting data in Open XDMoD datawarehouse
                 <div id="accountfact_content" class="statsbox"></div>
             </div>
-            <div id="mongo" class="mongodatastore">
-                Summary data
+            <div id="mongo" class="mongodatastore datastore">
+                Job summary documents
                 <div id="mongo_content" class="statsbox"></div>
             </div>
-            <div id="jobfact" class="sqldatastore">
-                SUPREMM Job facts
+            <div id="jobfact" class="sqldatastore datastore">
+                SUPREMM job records in Open XDMoD datawarehouse
                 <div id="jobfact_content" class="statsbox"></div>
             </div>
-            <div id="aggregates" class="sqldatastore">
-                Aggregate job data
+            <div id="pcpdatasource" class="datasource">
+                <span class="centered">PCP running on compute nodes</span>
+            </div>
+            <div id="resdatasource" class="datasource">
+                <span class="centered">Resource manager logs</span>
+            </div>
+            <div id="summarization_scripts" class="process">
+                <span class="centered">SUPReMM<br />summarization scripts</span>
+            </div>
+            <div id="etl_process" class="process">
+                <span class="centered">SUPReMM<br />ETL process</span>
+            </div>
+            <div id="aggregates" class="sqldatastore datastore">
+                Aggregated SUPReMM data in Open XDMoD datawarehouse
                 <div id="aggregates_content" class="statsbox"></div>
             </div>
-        </div>
-        <div id="key">
-            <p>Key:</p>
-            <ul>
-                <li><span class="filekey">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> File storage</li>
-                <li><span class="sqlkey">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> MySQL storage</li>
-                <li><span class="mongokey">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> Mongo storage</li>
-            </ul>
+            <div id="key">
+                <p>Key:</p>
+                <ul>
+                    <li><span class="filekey">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> File storage</li>
+                    <li><span class="sqlkey">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> MySQL storage</li>
+                    <li><span class="mongokey">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> Mongo storage</li>
+                </ul>
+            </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
## Description

- Update diagram to show Open XDMoD dataflow.
- Change orientation to resemble the dataflow diagram in the main documentation for consistency.
- All configured resources are now shown in the drop down rather than just the ones that have data in the datawarehouse.

![image](https://user-images.githubusercontent.com/5342179/28852447-2abf2710-76f7-11e7-9da8-62c9d20ce7aa.png)


## Motivation and Context
This page is intended to be used to help the support team diagnose problems with SUPReMM installs. Hopefully savvy users will be able to diagnose the source of problems themselves without our help.

## Tests performed
Installed this on metrics-dev and confirmed the page displays correctly in Firefox Linux, Chrome Linux, Firefox OSX and Chrome OSX
