### PR TITLE
Update the PCP install documentation

### DIFF
--- a/docs/supremm-compute-pcp.md
+++ b/docs/supremm-compute-pcp.md
@@ -66,6 +66,7 @@ These templates are available:
 ------------------------------
 #### /usr/share/supremm/templates/pmlogger/control
 * Moved to: /etc/pcp/pmlogger
+    * Remove any existing files under: /etc/pcp/pmlogger/control.d
 * **THIS CHANGE MUST BE MADE**
     * Edit the file to specify that the logs be written to shared space, accessable by the Supremm processing machine
     * "PCP_LOG_DIR/pmlogger/LOCALHOSTNAME"


### PR DESCRIPTION
The PCP RPM install puts a file in /etc/pcp/pmlogger/control.d
Need to delete this so pmlogger doesn't try to start multiple
loggers.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The PCP RPM install puts a file in /etc/pcp/pmlogger/control.d
Need to delete this so pmlogger doesn't try to start multiple
loggers.

## Motivation and Context
Documentation fix

## Tests performed
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
