### PR TITLE
Update migration script

### DIFF
--- a/db/migrations/7.5.0-8.0.0/modw_supremm.sql
+++ b/db/migrations/7.5.0-8.0.0/modw_supremm.sql
@@ -12,14 +12,11 @@ ALTER TABLE `modw_supremm`.`job`
 
 USE `modw_etl`;
 
+SET @updatetime = (SELECT UNIX_TIMESTAMP(NOW()));
+
 INSERT INTO `log`
     (etlProfileName, start_ts, end_ts, min_index, max_index, details)
-VALUES (
-    "modw_supremm.job",
-    UNIX_TIMESTAMP(now()),
-    UNIX_TIMESTAMP(now()),
-    0,
-    (SELECT UNIX_TIMESTAMP(MAX(last_modified)) FROM `modw_supremm`.`job`),
-    "{reason: \"7.5.0 - 8.0.0 migration\"}"
-);
+VALUES 
+    ("modw_supremm.job", @updatetime, @updatetime, 0, @updatetime, "{reason: \"7.5.0 - 8.0.0 migration\"}"),
+    ("modw_aggregates.supremmfact_by_day", @updatetime, @updatetime, 0, @updatetime, "{reason: \"7.5.0 - 8.0.0 migration\"}");
 


### PR DESCRIPTION
Fix two bugs: 
- When the last_modified column is added the rows get a value of '0000-00-00T00:00' which cannot be converted to a posix timestamp. This means that the etl.log table gets a null in the max_index column and results in a full re-aggregation.
- Add the modw_aggregates.supremmfact_by_day table to the log to prevent a full regeneration of the joblist table.