### PR TITLE
Only send confirmed analytics data

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
@@ -115,7 +115,7 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
                 $sfield = $sdata['key'];
                 // TODO work out a better way to have metrics have multiple
                 // meta-types (ie cpu user is an analytic as well as a metric).
-                if ($sdata['dtype'] == "analysis" || $sfield == "cpu_user") {
+                if ($sfield == "cpu_user") {
                     $this->addFieldWithError(new TableField($dataTable, $sfield), $sfield, $joberrors);
                     $this->documentation[$sfield] = $sdata;
                 }

--- a/tests/automated_tests/test/specs/jobViewer.page.js
+++ b/tests/automated_tests/test/specs/jobViewer.page.js
@@ -68,17 +68,22 @@ class JobViewer {
                 tabByName: function (name) {
                     return '//div[@id="info_display"]//span[contains(@class,"x-tab-strip-text") and contains(text(),"' + name + '")]';
                 },
-                tabById: function (jobid, infoid) {
+                tabById: function (jobid, infoid, extra) {
                     var infomap = {
                         0: 'kv',
                         2: 'nested',
                         4: 'kv',
                         5: 'metrics'
                     };
-                    return '#job_tabs-' + jobid + '__infoid_' + infoid + '_' + jobid + '_' + infomap[infoid];
+                    var restrictions = '';
+                    if (extra) {
+                        restrictions = extra;
+                    }
+
+                    return '//li[contains(@id,"__infoid_' + infoid + '_' + jobid + '_' + infomap[infoid] + '")' + restrictions + ']';
                 },
                 tabById_active: function (jobid, infoid) {
-                    return '//li[@id="' + module.exports.selectors.info.tabById(jobid, infoid).substring(1) + '" and contains(@class, "x-tab-strip-active")]';
+                    return module.exports.selectors.info.tabById(jobid, infoid, ' and contains(@class, "x-tab-strip-active")');
                 },
                 chart: {
                     titleByContainer: function (container) {


### PR DESCRIPTION
## Description
The jobviewer has been changed to automatically display the first 4 analytics. This change modifies
the anayltics send to the job viewer to only send the ones that have been vetted.