### PR TITLE
Add GPU stats from BlueWaters

### DIFF
--- a/tests/integration_tests/lib/REST/Warehouse/JobViewerTest.php
+++ b/tests/integration_tests/lib/REST/Warehouse/JobViewerTest.php
@@ -24,6 +24,7 @@ class JobViewerTest extends \PHPUnit_Framework_TestCase
             "parentscience",
             "exit_status",
             "netdrv_gpfs_rx_bucket_id",
+            "gpu0_nv_utilization_bucketid",
             "granted_pe",
             "ibrxbyterate_bucket_id",
             "netdrv_isilon_rx_bucket_id",


### PR DESCRIPTION
These GPU stats and group bys were developed for the BlueWaters workload analysis. This pul request includes them by default for the Open Source release