### PR TITLE
Added max-old-space-size flag to nodejs args

### DIFF
--- a/bin/aggregate_supremm.sh
+++ b/bin/aggregate_supremm.sh
@@ -23,7 +23,7 @@ fi
 
     cd ${XDMOD_SHARE_PATH}/etl/js
     
-    node etl.cluster.js $FLAGS
+    node --max-old-space-size=4096 etl.cluster.js $FLAGS
     
     php ${XDMOD_LIB_PATH}/supremm_sharedjobs.php $FLAGS
     


### PR DESCRIPTION
The default memory limit for nodejs is not large enough when running a large ingest (~million jobs). Bump the heap limit to 4G

Tested on metrics-dev and metrics-staging.