### PR TITLE
Update the module for the new Job Viewer internal API

### DIFF
--- a/build.json
+++ b/build.json
@@ -50,7 +50,7 @@
         "etc": {
             "configuration/portal_settings.d/supremm.ini": "portal_settings.d/supremm.ini",
             "configuration/datawarehouse.d/supremm.json": "datawarehouse.d/supremm.json",
-            "configuration/rawstatistics.d/supremm.json": "rawstatistics.d/supremm.json",
+            "configuration/rawstatistics.d/10_supremm.json": "rawstatistics.d/10_supremm.json",
             "configuration/rest.d/supremm_dataflow.json": "rest.d/supremm_dataflow.json",
             "configuration/roles.d/supremm.json": "roles.d/supremm.json",
             "configuration/roles.d/supremm:job-viewer.json": "roles.d/supremm:job-viewer.json",

--- a/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
@@ -23,7 +23,7 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
         $stat = "all"
     ) {
     
-        parent::__construct('SUPREMM', 'modw_supremm', 'job', $parameters);
+        parent::__construct('SUPREMM', 'modw_supremm', 'job', array());
 
         $this->loadRawStatsConfig();
 
@@ -48,6 +48,13 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
 
 
         $dataTable = $this->getDataTable();
+
+        if (isset($parameters['primary_key'])) {
+            $this->addPdoWhereCondition(new WhereCondition(new TableField($dataTable, '_id'), "=", $parameters['primary_key']));
+        } else {
+            $this->addPdoWhereCondition(new WhereCondition(new TableField($dataTable, 'resource_id'), '=', $parameters['resource_id']));
+            $this->addPdoWhereCondition(new WhereCondition(new TableField($dataTable, 'local_job_id'), '=', $parameters['job_identifier']));
+        }
 
         if ($stat == "accounting") {
             $i = 0;

--- a/classes/DataWarehouse/Query/SUPREMM/JobMetadata.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobMetadata.php
@@ -2,6 +2,8 @@
 
 namespace DataWarehouse\Query\SUPREMM;
 
+use \XDUser;
+
 function comparenodeid($a, $b)
 {
     if ($a['nodeid'] == $b['nodeid']) {
@@ -18,7 +20,7 @@ function comparecpuid($a, $b)
     return $a['cpuid'] < $b['cpuid'] ? -1 : 1;
 }
 
-class JobMetadata
+class JobMetadata implements \DataWarehouse\Query\iJobMetadata
 {
     private $supremmDbInterface = null;
 
@@ -28,7 +30,7 @@ class JobMetadata
         $this->supremmDbInterface = new \DataWarehouse\Query\SUPREMM\SupremmDbInterface();
     }
 
-    public function getJobMetadata($user, $jobid)
+    public function getJobMetadata(XDUser $user, $jobid)
     {
 
         // TODO This implementation performs multiple queries to generate the list of
@@ -42,7 +44,7 @@ class JobMetadata
         $available_data = array( \DataWarehouse\Query\RawQueryTypes::ACCOUNTING => true );
 
         $scriptquery = new \DataWarehouse\Query\SUPREMM\JobDataset(
-            array(new \DataWarehouse\Query\Model\Parameter("_id", "=", $jobid)),
+            array('primary_key' => $jobid),
             "jobscript"
         );
 
@@ -114,7 +116,7 @@ class JobMetadata
         return $merged;
     }
 
-    public function getJobSummary($user, $jobid)
+    public function getJobSummary(XDUser $user, $jobid)
     {
         $job = $this->lookupJob($user, $jobid);
         if ($job == null) {
@@ -131,7 +133,7 @@ class JobMetadata
         }
     }
 
-    private function redactLariat($user, $lariatdata)
+    private function redactLariat(XDUser $user, $lariatdata)
     {
         if ($user->getUserType() == DEMO_USER_TYPE) {
             $username = $lariatdata['user'];
@@ -146,7 +148,7 @@ class JobMetadata
         }
     }
 
-    public function getJobExecutableInfo($user, $jobid)
+    public function getJobExecutableInfo(XDUser $user, $jobid)
     {
         $job = $this->lookupJob($user, $jobid);
         if ($job == null) {
@@ -161,7 +163,7 @@ class JobMetadata
         return array();
     }
 
-    public function getJobTimeseriesMetaData($user, $jobid)
+    public function getJobTimeseriesMetaData(XDUser $user, $jobid)
     {
 
         // TODO The next three functions just parse the data from the db in order to work
@@ -200,7 +202,7 @@ class JobMetadata
         return $result;
     }
 
-    public function getJobTimeseriesMetricMeta($user, $jobid, $metric)
+    public function getJobTimeseriesMetricMeta(XDUser $user, $jobid, $metric)
     {
 
         $job = $this->lookupJob($user, $jobid);
@@ -240,7 +242,7 @@ class JobMetadata
         return $result;
     }
 
-    public function getJobTimeseriesMetricNodeMeta($user, $jobid, $metric, $nodeid)
+    public function getJobTimeseriesMetricNodeMeta(XDUser $user, $jobid, $metric, $nodeid)
     {
 
         $job = $this->lookupJob($user, $jobid);
@@ -274,7 +276,7 @@ class JobMetadata
         return $result;
     }
 
-    public function getJobTimeseriesData($user, $jobid, $tsid, $nodeid, $cpuid)
+    public function getJobTimeseriesData(XDUser $user, $jobid, $tsid, $nodeid, $cpuid)
     {
 
         $job = $this->lookupJob($user, $jobid);
@@ -306,9 +308,7 @@ class JobMetadata
      */
     private function lookupJob($user, $jobid)
     {
-        $params = array(new \DataWarehouse\Query\Model\Parameter("_id", "=", $jobid));
-
-        $query = new \DataWarehouse\Query\SUPREMM\JobDataset($params, "internal");
+        $query = new \DataWarehouse\Query\SUPREMM\JobDataset(array('primary_key' => $jobid), "internal");
         $query->setMultipleRoleParameters($user->getAllRoles(), $user);
         $stmt = $query->getRawStatement();
 

--- a/configuration/portal_settings.d/supremm.ini
+++ b/configuration/portal_settings.d/supremm.ini
@@ -1,6 +1,3 @@
-[features]
-singlejobviewer = "on"
-
 [supremm-general]
 
 ; The version number is updated during the upgrade process.

--- a/configuration/rawstatistics.d/10_supremm.json
+++ b/configuration/rawstatistics.d/10_supremm.json
@@ -1,0 +1,7 @@
+{
+    "+realms": {
+        "SUPREMM": {
+            "name": "SUPREMM"
+        }
+    }
+}

--- a/configuration/rawstatistics.d/supremm.json
+++ b/configuration/rawstatistics.d/supremm.json
@@ -1,9 +1,0 @@
-{
-    "+realms": {
-        "SUPREMM": {
-            "name": "SUPREMM",
-            "primary_key": "_id",
-            "ident_key": "local_job_id"
-        }
-    }
-}

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -1,6 +1,3 @@
-[features]
-singlejobviewer = "on"
-
 [supremm-general]
 
 ; The version number is updated during the upgrade process.

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -51,7 +51,7 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xdmod/roles.d/supremm*.json
 %config(noreplace) %{_sysconfdir}/xdmod/setup.d/supremm*.json
 %config(noreplace) %{_sysconfdir}/xdmod/rest.d/supremm*.json
-%config(noreplace) %{_sysconfdir}/xdmod/rawstatistics.d/supremm.json
+%config(noreplace) %{_sysconfdir}/xdmod/rawstatistics.d/10_supremm.json
 %config(noreplace) %{_sysconfdir}/xdmod/rawstatisticsconfig.json
 %config(noreplace) %{_sysconfdir}/xdmod/supremmconfig.json
 


### PR DESCRIPTION
Necessary changes for the Job Viewer API updates:
- remove singlejobviewer setting from portal_settings
- add numeric prefix to the rawstatistics.d config file
- JobMetadata inherits from the interface class
- JobDataset uses new API.