### PR TITLE
docker Power Up!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM tas-tools-ext-01.ccr.xdmod.org/xdmod-centos7:open8.0.0-supremm8.0.0-v1
+FROM tas-tools-ext-01.ccr.xdmod.org/xdmod-centos7:open8.0.0-supremm8.0.0-v2

--- a/tests/integration_tests/scripts/bootstrap.sh
+++ b/tests/integration_tests/scripts/bootstrap.sh
@@ -12,7 +12,7 @@ set -o pipefail
 
 if [ "$XDMOD_TEST_MODE" = "fresh_install" ];
 then
-    rm -rf /var/lib/mongodb/*
+    rm -rf /var/lib/mongo/*
     mongod -f /etc/mongod.conf
     ~/bin/importmongo.sh
     $XDMOD_BOOTSTRAP


### PR DESCRIPTION
update docker to have reccomended version of mongo installed specifically (3.4.18) from https://docs.mongodb.com/manual/tutorial/install-mongodb-on-red-hat/ instead of from base repos

