### PR TITLE
Remove last traces of the jobstatus table.

### DIFF
--- a/db/migrations/8.0.0-8.1.0/modw_supremm.sql
+++ b/db/migrations/8.0.0-8.1.0/modw_supremm.sql
@@ -1,0 +1,9 @@
+
+USE `modw_supremm`;
+
+DROP TRIGGER IF EXISTS `modw_supremm`.`jobafterinsert`;
+DROP TRIGGER IF EXISTS `modw_supremm`.`jobafterupdate`;
+DROP TRIGGER IF EXISTS `modw_supremm`.`jobbeforedel`;
+
+DROP TABLE IF EXISTS `modw_supremm`.`jobstatus`;
+

--- a/etl/js/config/supremm/etl.schema.js
+++ b/etl/js/config/supremm/etl.schema.js
@@ -64,12 +64,7 @@ module.exports = {
             extras: [
                 "KEY localjobid (resource_id,local_job_id)",
                   "KEY aggregation_index (end_time_ts,start_time_ts)"
-            ],
-            triggers: {
-                after_insert: "INSERT INTO jobstatus (job_id, aggregated_day, aggregated_month, aggregated_quarter, aggregated_year) VALUES (NEW._id, 0,0, 0, 0) ON DUPLICATE KEY UPDATE  aggregated_day = 0, aggregated_month = 0, aggregated_quarter = 0, aggregated_year = 0;",
-                after_update: "INSERT INTO jobstatus (job_id, aggregated_day, aggregated_month, aggregated_quarter, aggregated_year) VALUES (NEW._id, 0,0, 0, 0) ON DUPLICATE KEY UPDATE  aggregated_day = 0, aggregated_month = 0, aggregated_quarter = 0, aggregated_year = 0;",
-                before_del: "DELETE FROM  jobstatus WHERE job_id = OLD._id;"
-            }
+            ]
         }
     },
     dimension_tables: {

--- a/etl/js/config/supremm/output_db/modw_supremm.sql
+++ b/etl/js/config/supremm/output_db/modw_supremm.sql
@@ -374,27 +374,6 @@ CREATE TABLE `jobhost` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `jobstatus`
---
-
-DROP TABLE IF EXISTS `jobstatus`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `jobstatus` (
-  `job_id` int(11) NOT NULL,
-  `aggregated_day` bit(1) NOT NULL DEFAULT b'0',
-  `aggregated_month` bit(1) NOT NULL DEFAULT b'0',
-  `aggregated_quarter` bit(1) NOT NULL DEFAULT b'0',
-  `aggregated_year` bit(1) NOT NULL DEFAULT b'0',
-  PRIMARY KEY (`job_id`),
-  KEY `days` (`aggregated_day`),
-  KEY `months` (`aggregated_month`),
-  KEY `quarters` (`aggregated_quarter`),
-  KEY `years` (`aggregated_year`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `job_name`
 --
 

--- a/etl/js/config/supremm/output_db/supremm_reset.sql
+++ b/etl/js/config/supremm/output_db/supremm_reset.sql
@@ -12,7 +12,6 @@ DROP TABLE IF EXISTS modw_supremm.`job_errors`;
 TRUNCATE modw_supremm.`jobhost`;
 TRUNCATE modw_supremm.`job_name`;
 TRUNCATE modw_supremm.`job_peers`;
-TRUNCATE modw_supremm.`jobstatus`;
 
 DROP TABLE IF EXISTS modw_supremm.`pkgt`;
 DROP TABLE IF EXISTS modw_supremm.`sizet`;


### PR DESCRIPTION
The jobstatus table is not used as of the 8.0.0 release, but it
was incorrectly still being created on a fresh install. This change
fully removes the jobstatus table.