### PR TITLE
Add end_time_ts column to jobhost table 

### DIFF
--- a/background_scripts/supremm_sharedjobs.php
+++ b/background_scripts/supremm_sharedjobs.php
@@ -104,7 +104,7 @@ try
                 AND rf.shared_jobs = 1";
 
     $db->handle()->exec('DROP TABLE IF EXISTS `modw_supremm`.`job_tmp`');
-    $createtmp = $db->handle()->prepare('CREATE TABLE `modw_supremm`.`job_tmp` (KEY (resource_id, local_job_id)) SELECT _id, resource_id, local_job_id, start_time_ts, end_time_ts FROM `modw_supremm`.`job` WHERE end_time_ts BETWEEN :start AND :end');
+    $createtmp = $db->handle()->prepare('CREATE TABLE `modw_supremm`.`job_tmp` (KEY (resource_id, local_job_id, end_time_ts)) SELECT _id, resource_id, local_job_id, start_time_ts, end_time_ts FROM `modw_supremm`.`job` WHERE end_time_ts BETWEEN :start AND :end');
     $createtmp->execute(array('start' => $start, 'end' => $end));
 
     $jobsforhost = "SELECT 
@@ -115,6 +115,7 @@ try
             WHERE
                 jh.local_job_id = j.local_job_id
                 AND jh.resource_id = j.resource_id
+                AND jh.end_time_ts = j.end_time_ts
                 AND jh.host_id = :hostid
             UNION SELECT 
                 j._id as jobid, 's' as jobstate, j.start_time_ts as state_transition_timestamp
@@ -124,6 +125,7 @@ try
             WHERE
                 jh.local_job_id = j.local_job_id
                 AND jh.resource_id = j.resource_id
+                AND jh.end_time_ts = j.end_time_ts
                 AND jh.host_id = :hostid
             ORDER BY 3 ASC, 2 DESC";
 

--- a/configuration/etl/etl.d/supremm-migration-8_0_0-8_1_0.json
+++ b/configuration/etl/etl.d/supremm-migration-8_0_0-8_1_0.json
@@ -20,7 +20,18 @@
             "namespace": "ETL\\Maintenance",
             "options_class": "MaintenanceOptions",
             "definition_file_list": [
+                "supremm/jobhost.json",
                 "supremm/job.json"
+            ]
+        },
+        {
+            "name": "migrate-data",
+            "description": "Migrate data to new schema",
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "class": "ExecuteSql",
+            "sql_file_list": [
+                "supremm/migration-8_0_0-8_1_0.sql"
             ]
         }
     ]

--- a/configuration/etl/etl.d/supremm_realm.json
+++ b/configuration/etl/etl.d/supremm_realm.json
@@ -43,6 +43,7 @@
             "definition_file_list": [
                 "supremm/job.json",
                 "supremm/job_errors.json",
+                "supremm/jobhost.json",
                 "supremm/job_scripts.json"
             ]
         }

--- a/configuration/etl/etl_sql.d/supremm/migration-8_0_0-8_1_0.sql
+++ b/configuration/etl/etl_sql.d/supremm/migration-8_0_0-8_1_0.sql
@@ -1,0 +1,8 @@
+UPDATE
+    `modw_supremm`.`jobhost` jh, `modw_supremm`.`job` j
+SET
+    jh.`end_time_ts` = j.`end_time_ts`
+WHERE
+    jh.`resource_id` = j.`resource_id`
+    AND jh.`local_job_id` = j.`local_job_id`
+//

--- a/configuration/etl/etl_tables.d/supremm/jobhost.json
+++ b/configuration/etl/etl_tables.d/supremm/jobhost.json
@@ -1,0 +1,54 @@
+{
+    "table_definition": {
+        "name": "jobhost",
+        "engine": "MyISAM",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
+        "columns": [
+            {
+                "name": "host_id",
+                "type": "int(11)",
+                "nullable": false
+            },
+            {
+                "name": "local_job_id",
+                "type": "int(11)",
+                "nullable": false
+            },
+            {
+                "name": "resource_id",
+                "type": "int(11)",
+                "nullable": false
+            },
+            {
+                "name": "end_time_ts",
+                "type": "int(11)",
+                "nullable": false
+            }
+        ],
+        "indexes": [
+            {
+                "name": "PRIMARY",
+                "columns": [
+                    "host_id",
+                    "resource_id",
+                    "local_job_id",
+                    "end_time_ts"
+                ],
+                "type": "BTREE",
+                "is_unique": true
+            },
+            {
+                "name": "job_lookup",
+                "columns": [
+                    "resource_id",
+                    "local_job_id",
+                    "end_time_ts"
+                ],
+                "type": "BTREE",
+                "is_unique": false
+            }
+        ],
+        "triggers": []
+    }
+}

--- a/etl/js/config/supremm/etl.schema.js
+++ b/etl/js/config/supremm/etl.schema.js
@@ -414,9 +414,14 @@ module.exports = {
                         values: {resource_id: attributes.resource_id.value, name: attributes.hosts.value[i]}
                     });
                     ret.push({
-                        query: "insert ignore into modw_supremm.jobhost (local_job_id, resource_id, host_id) "
-                             + "values (:local_job_id, :resource_id, (select id from modw_supremm.host where resource_id = :resource_id and name = :name ))",
-                        values: {local_job_id: attributes.local_job_id.value, resource_id: attributes.resource_id.value, name: attributes.hosts.value[i]},
+                        query: 'insert ignore into modw_supremm.jobhost (local_job_id, resource_id, end_time_ts, host_id) '
+                             + 'values (:local_job_id, :resource_id, :end_time_ts, (select id from modw_supremm.host where resource_id = :resource_id and name = :name ))',
+                        values: {
+                            local_job_id: attributes.local_job_id.value,
+                            resource_id: attributes.resource_id.value,
+                            end_time_ts: attributes.end_time_ts.value,
+                            name: attributes.hosts.value[i]
+                        },
                         cacheable: false
                     });
                 }

--- a/etl/js/config/supremm/output_db/modw_supremm.sql
+++ b/etl/js/config/supremm/output_db/modw_supremm.sql
@@ -359,21 +359,6 @@ CREATE TABLE `host` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `jobhost`
---
-
-DROP TABLE IF EXISTS `jobhost`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `jobhost` (
-  `host_id` int(11) NOT NULL,
-  `local_job_id` int(11) NOT NULL,
-  `resource_id` int(11) NOT NULL,
-  PRIMARY KEY (`host_id`,`local_job_id`,`resource_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `job_name`
 --
 

--- a/tests/integration_tests/scripts/bootstrap.sh
+++ b/tests/integration_tests/scripts/bootstrap.sh
@@ -24,5 +24,6 @@ if [ "$XDMOD_TEST_MODE" = "upgrade" ];
 then
     mongod -f /etc/mongod.conf
     $XDMOD_BOOTSTRAP
+    cd /usr/share/xdmod/etl/js && npm install && cd -
     aggregate_supremm.sh
 fi

--- a/tests/integration_tests/scripts/validate.sh
+++ b/tests/integration_tests/scripts/validate.sh
@@ -38,4 +38,12 @@ then
     exitcode=1
 fi
 
+# Check that the jobhosts table has end_time_ts column with non-zero timestamps
+jobcount=$(echo 'SELECT COUNT(*) FROM modw_supremm.job j, modw_supremm.jobhost jh WHERE j.resource_id = jh.resource_id AND j.local_job_id = jh.local_job_id AND j.end_time_ts = jh.end_time_ts' | mysql -N modw_supremm)
+if [ $jobcount -eq 0 ];
+then
+    echo "Job Hosts table incorrect data"
+    exitcode=1
+fi
+
 exit $exitcode


### PR DESCRIPTION
## Description
The jobhost table did not include all of the columns needed to uniquely identify a job (in general). This update makes sure that the unique constraints on this table match the jobs table.

This change moves the jobhosts table management over to etlv2. 

## Motivation and Context
This is a problem for resources that have multiple jobs with the same local_job_id  and have shared jobs. It could result in a incorrect job share mode value being set on a job.