### PR TITLE
Replace `Config` usage

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
@@ -310,7 +310,7 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
             );
             $configFile->initialize();
 
-            $this->sconf = json_decode($configFile->toJson(), true);
+            $this->sconf = $configFile->toAssocArray();
         }
     }
 

--- a/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
@@ -1,6 +1,7 @@
 <?php
 namespace DataWarehouse\Query\SUPREMM;
 
+use Configuration\XdmodConfiguration;
 use \DataWarehouse\Query\Model\Table;
 use \DataWarehouse\Query\Model\TableField;
 use \DataWarehouse\Query\Model\Field;
@@ -303,8 +304,13 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
     private function loadRawStatsConfig()
     {
         if ($this->sconf == null) {
-            $config = \Xdmod\Config::factory();
-            $this->sconf = $config['rawstatisticsconfig'];
+            $configFile = new XdmodConfiguration(
+                'rawstatisticsconfig.json',
+                CONFIG_DIR
+            );
+            $configFile->initialize();
+
+            $this->sconf = json_decode($configFile->toJson(), true);
         }
     }
 

--- a/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
+++ b/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
@@ -2,17 +2,31 @@
 
 namespace DataWarehouse\Query\SUPREMM;
 
+use Configuration\XdmodConfiguration;
+
 class SupremmDbInterface {
     private $etl_version = null;
     private $resource_rmap = null;
 
     public function __construct() {
-        $config = \Xdmod\Config::factory();
+        $supremmConfigFile = new XdmodConfiguration(
+            'supremmconfig',
+            CONFIG_DIR
+        );
+        $supremmConfigFile->initialize();
 
-        $sconf = $config['supremmconfig'];
+        $sconf = json_decode($supremmConfigFile->toJson(), true);
         $this->etl_version = $sconf['etlversion'];
 
-        $resources = $config['supremm_resources']['resources'];
+        $supremmResourcesConfigFile = new XdmodConfiguration(
+            'supremm_resources.json',
+            CONFIG_DIR
+
+        );
+        $supremmResourcesConfigFile->initialize();
+
+        $supremmResourcesConfig = json_decode($supremmResourcesConfigFile->toJson(), true);
+        $resources = $supremmResourcesConfig['resources'];
 
         foreach($resources as $sresource) {
 

--- a/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
+++ b/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
@@ -10,7 +10,7 @@ class SupremmDbInterface {
 
     public function __construct() {
         $supremmConfigFile = new XdmodConfiguration(
-            'supremmconfig',
+            'supremmconfig.json',
             CONFIG_DIR
         );
         $supremmConfigFile->initialize();

--- a/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
+++ b/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
@@ -15,7 +15,7 @@ class SupremmDbInterface {
         );
         $supremmConfigFile->initialize();
 
-        $sconf = json_decode($supremmConfigFile->toJson(), true);
+        $sconf = $supremmConfigFile->toAssocArray();
         $this->etl_version = $sconf['etlversion'];
 
         $supremmResourcesConfigFile = new XdmodConfiguration(
@@ -25,7 +25,7 @@ class SupremmDbInterface {
         );
         $supremmResourcesConfigFile->initialize();
 
-        $supremmResourcesConfig = json_decode($supremmResourcesConfigFile->toJson(), true);
+        $supremmResourcesConfig = $supremmResourcesConfigFile->toAssocArray();
         $resources = $supremmResourcesConfig['resources'];
 
         foreach($resources as $sresource) {

--- a/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
+++ b/classes/DataWarehouse/Query/SUPREMM/SupremmDbInterface.php
@@ -21,7 +21,6 @@ class SupremmDbInterface {
         $supremmResourcesConfigFile = new XdmodConfiguration(
             'supremm_resources.json',
             CONFIG_DIR
-
         );
         $supremmResourcesConfigFile->initialize();
 


### PR DESCRIPTION
_**This commit depends on https://github.com/ubccr/xdmod/pull/806 and should not be merged until it has
been.**_

## Description
This commit will ensure that the SUPREMM module no longer uses the
`Xdmod\Config` class. This is part of the Configuration code consolidation
effort.

## Motivation and Context
No need to have two code paths for working with configuration code. 

## Tests performed
Manual Testing on xdmod-dev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code Refactor / Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
