### PR TITLE
Update mapping for InfiniBand metrics.

### DIFF
--- a/etl/js/config/supremm/dataset_maps/pcp.js
+++ b/etl/js/config/supremm/dataset_maps/pcp.js
@@ -545,7 +545,30 @@ module.exports = function(config) {
                 }
             },
             "ib_rx_bytes": {
-                ref: "infiniband.mlx4_0:1.switch-out-bytes.avg"
+                formula: function (job) {
+                    var ret_val = {
+                        value: null,
+                        error: this.metricErrors.codes.metricMissingUnknownReason.value
+                    };
+                    if (job.infiniband) {
+                        if (job.infiniband.error) {
+                            ret_val.error = job.infiniband.error;
+                            return ret_val;
+                        }
+
+                        for (let device in job.infiniband) {
+                            if (job.infiniband.hasOwnProperty(device)) {
+                                if (job.infiniband[device]['switch-out-bytes'] && job.infiniband[device]['switch-out-bytes'].avg) {
+                                    ret_val.value = job.infiniband[device]['switch-out-bytes'].avg;
+                                    ret_val.error = 0;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    return ret_val;
+                }
             },
             "block_sda_wr_ios": {
                 ref: "block.sda.write.avg"

--- a/etl/js/config/supremm/tests/pcp/expected/5659085-1469572318.json
+++ b/etl/js/config/supremm/tests/pcp/expected/5659085-1469572318.json
@@ -213,8 +213,8 @@
         "error": 0
     },
     "ib_rx_bytes": {
-        "value": null,
-        "error": 8
+        "value": 369576,
+        "error": 0
     },
     "block_sda_wr_ios": {
         "value": 5031.5,


### PR DESCRIPTION
The dateset mapping for infiniband metrics will now use the first infiniband device
in the summary record for data. Previously it hardcoded a specific device name (which
only existed on a subset of nodes at CCR).