### PR TITLE
Update EtlConfiguration to use factory()

### DIFF
--- a/background_scripts/aggregate_supremm.php
+++ b/background_scripts/aggregate_supremm.php
@@ -104,7 +104,7 @@ try
         $scriptOptions['last-modified-start-date'] = $last_modified;
     }
 
-    $etlConfig = new \ETL\Configuration\EtlConfiguration(
+    $etlConfig = \ETL\Configuration\EtlConfiguration::factory(
         CONFIG_DIR . '/etl/etl.json',
         null,
         $logger,
@@ -113,7 +113,6 @@ try
             'default_module_name' => $scriptOptions['default-module-name']
         )
     );
-    $etlConfig->initialize();
     $overseerOptions = new \ETL\EtlOverseerOptions($scriptOptions, $logger);
     $overseer = new \ETL\EtlOverseer($overseerOptions, $logger);
     $overseer->execute($etlConfig);
@@ -138,13 +137,12 @@ try
         $scriptOptions['last-modified-start-date'] = $last_modified;
     }
 
-    $etlConfig = new \ETL\Configuration\EtlConfiguration(
+    $etlConfig = \ETL\Configuration\EtlConfiguration::factory(
         CONFIG_DIR . '/etl/etl.json',
         null,
         $logger,
         array('default_module_name' => $scriptOptions['default-module-name'])
     );
-    $etlConfig->initialize();
     $overseerOptions = new \ETL\EtlOverseerOptions($scriptOptions, $logger);
     $overseer = new \ETL\EtlOverseer($overseerOptions, $logger);
     $overseer->execute($etlConfig);

--- a/classes/OpenXdmod/Setup/SupremmDbSetup.php
+++ b/classes/OpenXdmod/Setup/SupremmDbSetup.php
@@ -91,8 +91,7 @@ EOT
                 )
             );
 
-            $etlConfig = new \ETL\Configuration\EtlConfiguration(CONFIG_DIR . '/etl/etl.json', null, $logger, array());
-            $etlConfig->initialize();
+            $etlConfig = \ETL\Configuration\EtlConfiguration::factory(CONFIG_DIR . '/etl/etl.json', null, $logger, array());
             \ETL\Utilities::setEtlConfig($etlConfig);
             $overseerOptions = new \ETL\EtlOverseerOptions($scriptOptions, $logger);
             $overseer = new \ETL\EtlOverseer($overseerOptions, $logger);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `Configuration` and child classes now require objects be instantiated using one of the `factory()` methods rather than `new Configuration()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
