### PR TITLE
Run base xdmod integration tests

### DIFF
--- a/tests/integration_tests/runtests.sh
+++ b/tests/integration_tests/runtests.sh
@@ -10,4 +10,8 @@ if [ ! -x "$phpunit" ]; then
     exit 127
 fi
 
+# Run subset of xdmod tests that work with this module
+$phpunit ${PHPUNITARGS} ../../../xdmod/tests/integration/lib/Rest/ReportThumbnailsTest.php
+
+# Run module specific tests
 $phpunit ${PHPUNITARGS} .


### PR DESCRIPTION
Need to run some of the base XDMoD integration tests to ensure the state of the system is correct for subsequent tests.