### PR TITLE
Add order by end_time to RawData

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/RawData.php
+++ b/classes/DataWarehouse/Query/SUPREMM/RawData.php
@@ -5,6 +5,7 @@ use \DataWarehouse\Query\Model\Table;
 use \DataWarehouse\Query\Model\TableField;
 use \DataWarehouse\Query\Model\WhereCondition;
 use \DataWarehouse\Query\Model\Schema;
+use \DataWarehouse\Query\Model\OrderBy;
 
 /* 
 * @author Amin Ghadersohi
@@ -82,7 +83,9 @@ class RawData extends \DataWarehouse\Query\Query
                 // All other metrics show running job count
                 break;
         }
-	}
+
+        $this->addOrder(new OrderBy(new TableField($factTable, 'end_time_ts'), 'DESC', 'end_time_ts'));
+    }
 
     public function getQueryString($limit = NULL, $offset = NULL, $extraHavingClause = NULL)
     {


### PR DESCRIPTION
This ensures that the results of the advanced search and the recent jobs portlet are ordered
in time and the paging works as expected.

