### PR TITLE
The supremm menu is now option 9.

### DIFF
--- a/tests/integration_tests/scripts/xdmod-setup.tcl
+++ b/tests/integration_tests/scripts/xdmod-setup.tcl
@@ -60,7 +60,7 @@ proc confirmFileWrite { response } {
 set timeout 10
 spawn "xdmod-setup"
 
-selectMenuOption 8
+selectMenuOption 9
 
 selectMenuOption d
 answerQuestion {DB Admin Username:} root


### PR DESCRIPTION
The DataWArehouse Export feature added a new menu item to `xdmod-setup`. This means that the SUPREMM menu is pushed down one.