### PR TITLE
Ensure JobEfficiency realm is not shown in metric catalog

### DIFF
--- a/configuration/datawarehouse.d/jobefficiency.json
+++ b/configuration/datawarehouse.d/jobefficiency.json
@@ -3,6 +3,7 @@
         "JobEfficiency": {
             "schema": "N/A",
             "table": "N/A",
+            "show_in_catalog": false,
             "datasource": "SUPREMM",
             "group_bys": [
                 {

--- a/tests/integration_tests/lib/Controllers/MetricExplorerControllerTest.php
+++ b/tests/integration_tests/lib/Controllers/MetricExplorerControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace IntegrationTests\Controllers;
+
+class MetricExplorerControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Check that the SUPREMM realm shows in the metric explorer
+     * catalog and the JobEfficiency realm does not.
+     */
+    public function testGetDwDescripter()
+    {
+        $helper = new \TestHarness\XdmodTestHelper();
+        $helper->authenticate('cd');
+
+        $response = $helper->post('/controllers/metric_explorer.php', null, array('operation' => 'get_dw_descripter'));
+
+        $this->assertEquals('application/json', $response[1]['content_type']);
+        $this->assertEquals(200, $response[1]['http_code']);
+
+        $dwdata = $response[0];
+
+        $this->assertArrayHasKey('SUPREMM', $dwdata['data']['0']['realms']);
+        $this->assertArrayNotHasKey('JobEfficiency', $dwdata['data']['0']['realms']);
+    }
+}

--- a/tests/integration_tests/lib/Controllers/UserInterfaceControllerTest.php
+++ b/tests/integration_tests/lib/Controllers/UserInterfaceControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace IntegrationTests\Controllers;
+
+class UserInterfaceControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Check that the SUPREMM realm shows in the usage tab
+     * catalog and the JobEfficiency realm does not.
+     */
+    public function testGetMenus()
+    {
+        $helper = new \TestHarness\XdmodTestHelper();
+        $helper->authenticate('cd');
+
+        $params = array(
+            'operation' => 'get_menus',
+            'node' => 'category_',
+            'public_user' => false,
+            'query_group' => 'tg_usage'
+        );
+
+        $response = $helper->post('/controllers/user_interface.php', null, $params);
+
+        $this->assertEquals('application/json', $response[1]['content_type']);
+        $this->assertEquals(200, $response[1]['http_code']);
+
+        $data = $response[0];
+
+        $realms = array();
+        foreach ($data as $menuitem) {
+            if (isset($menuitem['realm'])) {
+                if (!isset($realms[$menuitem['realm']])) {
+                    $realms[$menuitem['realm']] = 0;
+                }
+                $realms[$menuitem['realm']] += 1;
+            }
+        }
+
+        $this->assertArrayHasKey('SUPREMM', $realms);
+        $this->assertArrayNotHasKey('JobEfficiency', $realms);
+
+        // The count represents the number of group bys in the realm
+        $this->assertTrue($realms['SUPREMM'] > 29);
+    }
+}

--- a/tests/integration_tests/lib/REST/Warehouse/DataTest.php
+++ b/tests/integration_tests/lib/REST/Warehouse/DataTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace IntegrationTests\REST\Warehouse;
+
+class DataTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $xdmodhelper;
+
+    const ENDPOINT = 'rest/v0.1/warehouse/';
+
+    public static function setUpBeforeClass()
+    {
+        self::$xdmodhelper = new \TestHarness\XdmodTestHelper();
+        self::$xdmodhelper->authenticate('cd');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$xdmodhelper->logout();
+    }
+
+    public function testRealms() {
+
+        $response = self::$xdmodhelper->get(self::ENDPOINT . 'realms', array());
+
+        $this->assertEquals(200, $response[1]['http_code']);
+
+        $data = $response[0];
+        $this->assertTrue($data['success']);
+
+        $this->assertContains('SUPREMM', $data['results']);
+        $this->assertContains('JobEfficiency', $data['results']);
+    }
+
+    public function testAggregateData() {
+
+        $params = array(
+            'start' => 0,
+            'limit' => 10,
+            'config' => json_encode(array(
+                'realm' => 'JobEfficiency',
+                'group_by' => 'person',
+                'statistics' => array('core_time_bad', 'bad_core_ratio'),
+                'aggregation_unit' => 'day',
+                'start_date' => '2016-12-01',
+                'end_date' => '2017-01-01',
+                'order_by' => array('field' => 'core_time_bad', 'dirn' => 'desc')
+            ))
+        );
+        $response = self::$xdmodhelper->get(self::ENDPOINT . 'aggregatedata', $params);
+
+        $this->assertEquals(200, $response[1]['http_code']);
+
+        $data = $response[0];
+        $this->assertArrayHasKey('success', $data);
+        $this->assertArrayHasKey('results', $data);
+        $this->assertArrayHasKey('total', $data);
+
+        $this->assertTrue($data['success']);
+        $this->assertEquals(min($data['total'], $params['limit']), count($data['results']));
+    }
+}


### PR DESCRIPTION
Update the config for the JobEfficiencty realm so that it is not shown in the catalog and add tests to confirm that it is not available to the Metric or Usage tabs and is available to the data access rest endpoints.

This pull request depends on ubccr/xdmod#1047