### PR TITLE
Add GroupByProvider.

### DIFF
--- a/classes/DataWarehouse/Query/JobEfficiency/GroupBys/GroupByProvider.php
+++ b/classes/DataWarehouse/Query/JobEfficiency/GroupBys/GroupByProvider.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace DataWarehouse\Query\JobEfficiency\GroupBys;
+
+class GroupByProvider extends \DataWarehouse\Query\JobEfficiency\GroupBy
+{
+    public static function getLabel()
+    {
+         return 'Service Provider';
+    }
+
+    public function getInfo()
+    {
+        return     'A service provider is an institution that hosts resource(s).';
+    }
+
+    public function __construct()
+    {
+        parent::__construct('provider', array(), 'SELECT distinct
+                                gt.organization_id as id,
+                                gt.short_name as short_name,
+                                gt.long_name as long_name
+                                FROM
+                                serviceprovider gt
+                                where 1
+                                order by gt.order_id', array('resource'));
+        $this->_id_field_name = 'organization_id';
+        $this->_long_name_field_name = 'short_name';
+        $this->_short_name_field_name = 'short_name';
+        $this->_order_id_field_name = 'order_id';
+        $this->modw_schema = new \DataWarehouse\Query\Model\Schema('modw');
+        $this->organization_table = new \DataWarehouse\Query\Model\Table($this->modw_schema, 'serviceprovider', 'sp');
+    }
+
+    public function applyTo(\DataWarehouse\Query\Query &$query, \DataWarehouse\Query\Model\Table $data_table, $multi_group = false)
+    {
+        $query->addTable($this->organization_table);
+
+        $id_field = new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_id_field_name, $this->getIdColumnName($multi_group));
+        $organization_name_field = new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_long_name_field_name, $this->getLongNameColumnName($multi_group));
+        $organization_shortname_field = new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_short_name_field_name, $this->getShortNameColumnName($multi_group));
+        $order_id_field = new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_order_id_field_name, $this->getOrderIdColumnName($multi_group));
+
+        $query->addField($order_id_field);
+        $query->addField($id_field);
+        $query->addField($organization_name_field);
+        $query->addField($organization_shortname_field);
+
+        $query->addGroup($id_field);
+
+        $datatable_organization_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'organization_id');
+        $query->addWhereCondition(new \DataWarehouse\Query\Model\WhereCondition($id_field, '=', $datatable_organization_id_field));
+
+        $this->addOrder($query, $multi_group);
+
+    }
+
+    public function addWhereJoin(
+        \DataWarehouse\Query\Query &$query,
+        \DataWarehouse\Query\Model\Table $data_table,
+        $multi_group,
+        $operation,
+        $whereConstraint
+    ) {
+        // construct the join between the main data_table and this group by table
+        $query->addTable($this->organization_table);
+
+        $id_field = new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_id_field_name);
+        $datatable_organization_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'organization_id');
+
+        // the where condition that specifies the join of the tables
+        $query->addWhereCondition(new \DataWarehouse\Query\Model\WhereCondition(
+            $id_field,
+            '=',
+            $datatable_organization_id_field
+        ));
+
+        // the where condition that specifies the constraint on the joined table
+        if (is_array($whereConstraint)) {
+            $whereConstraint="(". implode(",", $whereConstraint) .")";
+        }
+
+        $query->addWhereCondition(
+            new \DataWarehouse\Query\Model\WhereCondition(
+                $id_field,
+                $operation,
+                $whereConstraint
+            )
+        );
+    }
+
+    public function addOrder(\DataWarehouse\Query\Query &$query, $multi_group = false, $dir = 'asc', $prepend = false)
+    {
+        $orderField = new \DataWarehouse\Query\Model\OrderBy(new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_order_id_field_name), $dir, $this->getName());
+        if($prepend === true)
+        {
+            $query->prependOrder($orderField);
+        }else
+        {
+            $query->addOrder($orderField);
+        }
+    }
+
+    public function pullQueryParameters(&$request)
+    {
+        return parent::pullQueryParameters2($request, '_filter_', 'organization_id');
+    }
+
+    public function pullQueryParameterDescriptions(&$request)
+    {
+        return parent::pullQueryParameterDescriptions2(
+            $request,
+            "select short_name as field_label from modw.organization  where id in (_filter_) order by order_id"
+        );
+    }
+
+    public function getCategory()
+    {
+        return 'Administrative';
+    }
+}

--- a/configuration/datawarehouse.d/jobefficiency.json
+++ b/configuration/datawarehouse.d/jobefficiency.json
@@ -23,6 +23,10 @@
                     "class": "GroupByInstitution"
                 },
                 {
+                    "name": "provider",
+                    "class": "GroupByProvider"
+                },
+                {
                     "name": "category",
                     "class": "GroupByCategory"
                 },


### PR DESCRIPTION
The Provider group by is needed so that users with center staff and
center director role can see the efficiency report for jobs from their
center in the XSEDE version.

The absence of this group by was not a problem for the open source version because there is only a single provider 