### PR TITLE
composer quit being so annoying

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,10 @@
 language: none
 env:
-    - XDMOD_TEST_MODE=fresh_install
-    - XDMOD_TEST_MODE=upgrade
+    global:
+        - COMPOSER_ALLOW_SUPERUSER=1
+    matrix:
+        - XDMOD_TEST_MODE=fresh_install
+        - XDMOD_TEST_MODE=upgrade
 build:
     cache: true
     cache_dir_list:


### PR DESCRIPTION
turns off the composer warning about running as root, since we know we are doing this for a reason.