### PR TITLE
Add XDMOD_REALMS environment variable to build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
         - XDMOD_TEST_ARTIFACTS_MIRROR="$HOME/xdmod-test-artifacts.git"
         - XDMOD_MODULE_DIR="supremm"
         - XDMOD_MODULE_NAME="SUPReMM"
+        - XDMOD_REALMS="jobs,storage,cloud,supremm,jobefficiency"
 
 # Add dependency directories to the Travis cache
 cache:

--- a/shippable.yml
+++ b/shippable.yml
@@ -2,6 +2,7 @@ language: none
 env:
     global:
         - COMPOSER_ALLOW_SUPERUSER=1
+        - XDMOD_REALMS='jobs,storage,cloud,supremm,jobefficiency'
     matrix:
         - XDMOD_TEST_MODE=fresh_install
         - XDMOD_TEST_MODE=upgrade


### PR DESCRIPTION
The XDMOD_REALMS environment variable became mandatory as of
https://github.com/ubccr/xdmod/pull/1261
