### PR TITLE
Add job script documentation for 8.5

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -31,6 +31,8 @@ toc:
     subfolderitems:
       - page: PCP Data collection
         url: /supremm-compute-pcp.html
+      - page: Job Batch Script collection
+        url: /supremm-jobscript.html
       - page: Job Performance module
         url: /supremm-configuration.html
       - page: Job Summarization

--- a/docs/supremm-jobscript.md
+++ b/docs/supremm-jobscript.md
@@ -1,0 +1,32 @@
+The job viewer tab in Open XDMoD is able to show the job batch script along
+with the other job information. The job batch scripts are stored in the
+database using the `ingest_jobscripts.py` process. The `ingest_jobscripts.py` tool is
+packaged with the [Job Summarization software](supremm-processing-install.md).
+
+The ingestion of job batch scripts is an optional feature. It is _not_ required for Open XDMoD
+to display job performance information.
+
+The mechanism for extracting the job batch script is resource manager specific. Consult the
+documentation for your resource manager software for information about
+how to enable logging of the job batch script.
+
+## Source data schema
+
+In order to ingest the job batch script data into Open XDMoD the job batch scripts must be stored in files. There
+must be one file per job and the job batch scripts for a given day should be stored in a
+datestamp named directory:
+```
+[BASEPATH]/YYYYMMDD/JOBID.savescript
+```
+where `YYYY` is the four digit year, `MM` two digit month, `DD` two digit day
+and `JOBID` is the identifier for the job from the resource manager.
+The date must be the submit day of the job.  The configuration
+setting for the path name is described in the [configuration guide](supremm-processing-configuration.md).
+
+The files are stored in datestamped directories because:
+1. Storing the files by date limits the number of files per directory.
+1. The datestamp is also used along with the job identifier to locate
+the accounting record for the job. The datestamp is used because job identifiers
+provided by a resource manager are typically not globally unique.
+1. The datestamp is used to limit the number of files to scan each time the
+`ingest_jobscripts.py` process runs.

--- a/docs/supremm-processing-configuration.md
+++ b/docs/supremm-processing-configuration.md
@@ -89,6 +89,45 @@ available, then the `script_dir` field should be set to an empty string.
 }
 ```
 
+The various settings are described in the table below:
+<table>
+<thead>
+<tr>
+<th>Setting</th> <th>Allowed values</th> <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>enabled</code></td><td><code>true</code> | <code>false</code></td><td>If set to <code>false</code> then this resource will be ignored by the software</td>
+</tr>
+<tr>
+<td><code>resource_id</code></td><td>[integer]</td><td>The value from the <code>id</code> column in the <code>modw</code>.<code>resourcefact</code> table in the XDMoD database</td>
+</tr>
+<tr>
+<td><code>batch_system</code></td><td><code>XDMoD</code></td><td>Sets the module used to obtain job accounting information. This should be set to XDMoD</td>
+</tr>
+<tr>
+<td><code>hostname_mode</code></td><td><code>hostname</code> | <code>fqdn</code></td><td>Determines how compute node names as reported by the resource manager are compared
+with the node name information from the PCP archives. In <code>hostname</code> mode only the hostname of nodes is used to
+match nodes. In <code>fqdn</code> (full-qualified domain name) mode then the full name is used.</td>
+</tr>
+<tr>
+<td><code>host_name_ext</code></td><td>[domain name]</td><td>If the hostname_mode is fqdn and the host_name_ext is specified then the string will
+be appended to the node name from the PCP archives if it is absent. This is used to workaround misconfigured /etc/hosts files.
+This setting should be omitted if not required.</td>
+</tr>
+<tr>
+<td><code>pcp_log_dir</code></td><td>[filesystem path]</td><td>Path to the PCP log files for the resource.</td>
+</tr>
+<tr>
+<td><code>script_dir</code></td><td>[filesystem path]</td><td>Path to the batch script files. The batch scripts must be stored following
+the naming convention described in the <a href="supremm-jobscript.html">job script documentation</a>. Set this to an empty string if the
+batch script files are not saved.</td>
+</tr>
+</tbody>
+</table>
+<br />
+
 Database authentication settings
 --------------------------------
 


### PR DESCRIPTION
This is the same documentation as #222 backported to the 8.5 version of the software