### PR TITLE
Update application categorization for pegasus.

### DIFF
--- a/configuration/etl/etl.d/supremm-migration-8_5_1-9_0_0.json
+++ b/configuration/etl/etl.d/supremm-migration-8_5_1-9_0_0.json
@@ -1,0 +1,27 @@
+{
+    "module": "supremm",
+    "defaults": {
+        "global": {
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "SUPReMM DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_supremm"
+                }
+            }
+        }
+    },
+    "migration-8_5_1-9_0_0": [
+        {
+            "name": "update-application-ident",
+            "description": "Update the application identification",
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "class": "ExecuteSql",
+            "sql_file_list": [
+                "supremm/migration-8_5_1-9_0_0.sql"
+            ]
+        }
+    ]
+}

--- a/configuration/etl/etl_sql.d/supremm/migration-8_5_1-9_0_0.sql
+++ b/configuration/etl/etl_sql.d/supremm/migration-8_5_1-9_0_0.sql
@@ -1,0 +1,9 @@
+USE modw_supremm;
+
+LOCK TABLES application WRITE, job AS j WRITE, executable AS e READ;
+
+UPDATE application SET license_type = 'permissive', url = 'https://pegasus.isi.edu' WHERE id = 34;
+
+UPDATE job j, executable e SET j.application_id = 34 WHERE j.executable_id = e.id AND e.`binary` like 'pegasus%';
+
+UNLOCK TABLES;

--- a/etl/js/config/supremm/application.json
+++ b/etl/js/config/supremm/application.json
@@ -394,9 +394,11 @@
     {
         "id": 34,
         "name": "pegasus",
-        "license_type": "proprietary",
-        "hints": [
-            "pegasus"
+        "url": "https://pegasus.isi.edu",
+        "science_area": "uncategorized",
+        "license_type": "permissive",
+        "execmatch": [
+            "^pegasus"
         ]
     },
     {


### PR DESCRIPTION
The pegasus software was incorrectly marked as proprietary. This change updates
the application identification info so that new ingests will have the correct
identification. The migration file updates the existing records to change the
ident to the correct one.

The next time aggregation runs it will automatically re-aggregate the rows that
need to be redone.


