### PR TITLE
Add drilldown to jobs for the JobEfficiency component.

### DIFF
--- a/classes/DataWarehouse/Query/JobEfficiency/RawData.php
+++ b/classes/DataWarehouse/Query/JobEfficiency/RawData.php
@@ -1,0 +1,162 @@
+<?php
+namespace DataWarehouse\Query\JobEfficiency;
+
+use \DataWarehouse\Query\Model\Table;
+use \DataWarehouse\Query\Model\TableField;
+use \DataWarehouse\Query\Model\WhereCondition;
+use \DataWarehouse\Query\Model\Schema;
+use \DataWarehouse\Query\Model\OrderBy;
+
+/*
+ * Implementation of the RawData API for the JobEfficiency realm. This
+ * class is almost identical to the SUPREMM realm version except that the
+ * aggregate tables are the jobefficiency_by_ ones. The fact tables are the
+ * SUPREMM ones.
+ */
+class RawData extends \DataWarehouse\Query\Query implements \DataWarehouse\Query\iQuery
+{
+    /**
+     * @see Query::__construct()
+     */
+    public function __construct(
+        $realmId,
+        $aggregationUnitName,
+        $start_date,
+        $end_date,
+        $groupById = null,
+        $statisticId = null,
+        array $parameters = array(),
+        Log $logger = null
+    ) {
+        parent::__construct(
+            'JobEfficiency',
+            $aggregationUnitName,
+            $start_date,
+            $end_date,
+            $groupById,
+            null,
+            $parameters
+        );
+
+        $dataTable = $this->getDataTable();
+        $joblistTable = new Table($dataTable->getSchema(), $dataTable->getName() . '_joblist', 'jl');
+        $factTable = new Table(new Schema('modw_supremm'), 'job', 'sj' );
+
+        $resourcefactTable = new Table(new Schema('modw'), 'resourcefact', 'rf');
+        $this->addTable($resourcefactTable);
+
+        $this->addWhereCondition(new WhereCondition(
+            new TableField($dataTable, 'resource_id'),
+            '=',
+            new TableField($resourcefactTable, 'id')
+        ));
+
+        $personTable = new Table(new Schema('modw'), 'person', 'p');
+
+        $this->addTable($personTable);
+        $this->addWhereCondition(new WhereCondition(
+            new TableField($dataTable, 'person_id'),
+            '=',
+            new TableField($personTable, 'id')
+        ));
+
+        $this->addField(new TableField($resourcefactTable, 'code', 'resource'));
+        $this->addField(new TableField($personTable, 'long_name', 'name'));
+
+        $this->addField(new TableField($factTable, '_id', 'jobid'));
+        $this->addField(new TableField($factTable, 'local_job_id'));
+        $this->addField(new TableField($factTable, 'start_time_ts'));
+        $this->addField(new TableField($factTable, 'end_time_ts'));
+        $this->addField(new TableField($factTable, 'cpu_user'));
+
+        $this->addTable($joblistTable);
+        $this->addTable($factTable);
+
+        $this->addWhereCondition(new WhereCondition(
+            new TableField($joblistTable, 'agg_id'),
+            '=',
+            new TableField($dataTable, 'id')
+        ));
+        $this->addWhereCondition(new WhereCondition(
+            new TableField($joblistTable, 'jobid'),
+            '=',
+            new TableField($factTable, '_id')
+        ));
+
+        switch($statisticId) {
+            case 'job_count':
+                $this->addWhereCondition(new WhereCondition('sj.end_time_ts', 'BETWEEN', 'duration.day_start_ts and duration.day_end_ts') );
+                break;
+            case 'started_job_count':
+                $this->addWhereCondition(new WhereCondition('sj.start_time_ts', 'BETWEEN', 'duration.day_start_ts and duration.day_end_ts') );
+                break;
+            default:
+                // All other metrics show running job count
+                break;
+        }
+
+        $this->addOrder(new OrderBy(new TableField($factTable, 'end_time_ts'), 'DESC', 'end_time_ts'));
+    }
+
+    /**
+     * @see iQuery::getQueryString()
+     */
+    public function getQueryString($limit = null, $offset = null, $extraHavingClause = null)
+    {
+        $wheres = $this->getWhereConditions();
+        $groups = $this->getGroups();
+
+        $select_tables = $this->getSelectTables();
+        $select_fields = $this->getSelectFields();
+
+        $select_order_by = $this->getSelectOrderBy();
+
+        $data_query = 'SELECT DISTINCT '.implode(', ', $select_fields).
+            ' FROM '.implode(', ', $select_tables).
+            ' WHERE '.implode(' AND ', $wheres);
+
+        if (count($groups) > 0) {
+            $data_query .= " GROUP BY \n" . implode(",\n", $groups);
+        }
+        if ($extraHavingClause != null) {
+            $data_query .= ' HAVING ' . $extraHavingClause . "\n";
+        }
+        if (count($select_order_by) > 0) {
+            $data_query .= " ORDER BY \n" . implode(",\n", $select_order_by);
+        }
+
+        if ($limit !== null && $offset !== null) {
+            $data_query .= " LIMIT $limit OFFSET $offset";
+        }
+        return $data_query;
+    }
+
+    /**
+     * @see iQuery::getCountQueryString()
+     */
+    public function getCountQueryString()
+    {
+        $wheres = $this->getWhereConditions();
+        $groups = $this->getGroups();
+
+        $select_tables = $this->getSelectTables();
+        $select_fields = $this->getSelectFields();
+
+        $data_query = 'SELECT COUNT(*) AS row_count FROM (SELECT DISTINCT '.implode(', ', $select_fields).
+            ' FROM '.implode(', ', $select_tables).
+            ' WHERE '.implode(' AND ', $wheres);
+
+        if (count($groups) > 0) {
+            $data_query .= " GROUP BY \n".implode(",\n", $groups);
+        }
+        return $data_query . ') as a';
+    }
+
+    /**
+     * @see iQuery::getQueryType()
+     */
+    public function getQueryType()
+    {
+        return 'timeseries';
+    }
+}

--- a/configuration/datawarehouse.d/ref/job-efficiency-group-bys.json
+++ b/configuration/datawarehouse.d/ref/job-efficiency-group-bys.json
@@ -10,7 +10,7 @@
     "attribute_values_query": {
       "joins": [
         {
-          "name": "organization"
+          "name": "job_category"
         }
       ],
       "orderby": [

--- a/configuration/etl/etl_action_defs.d/jobefficiency/jobefficiency_by.json
+++ b/configuration/etl/etl_action_defs.d/jobefficiency/jobefficiency_by.json
@@ -51,6 +51,7 @@
         },
         "groupby": [
             "application_id",
+            "job_category_id",
             "fos_id",
             "organization_id",
             "person_id",

--- a/configuration/etl/etl_action_defs.d/jobefficiency/jobefficiency_by_day.json
+++ b/configuration/etl/etl_action_defs.d/jobefficiency/jobefficiency_by_day.json
@@ -52,6 +52,7 @@
         },
         "groupby": [
             "application_id",
+            "job_category_id",
             "fos_id",
             "organization_id",
             "person_id",

--- a/docs/supremm-upgrade.md
+++ b/docs/supremm-upgrade.md
@@ -22,7 +22,7 @@ be updated to the correct values. If this reaggregation step is not run then
 the list of jobs in  the drilldown could include jobs that are not categorized
 as inefficient.
 
-After the XDMoD upgrade procedure has completed the followgin command should
+After the XDMoD upgrade procedure has completed the following command should
 be run:
 ```bash
 /usr/share/xdmod/tools/etl/etl_overseer.php --last-modified-start-date 2000-01-01 -p jobefficiency.aggregation -p jobefficiency.joblist

--- a/docs/supremm-upgrade.md
+++ b/docs/supremm-upgrade.md
@@ -11,47 +11,21 @@ page](https://open.xdmod.org/upgrade.html).  The ingestion and aggregation
 script `aggregate_supremm.sh` **must** be run after the XDMoD software has been
 upgraded.
 
-8.1.0 to 8.5.0 Upgrade Notes
+8.5.1 to 9.0.0 Upgrade Notes
 ----------------------------
 
-- This upgrade includes database schema changes.
-    - Modifies `modw_supremm` schema.
-    - Modifies the `modw_aggregates.supremmfact_by_` tables.
+This upgrade fixes an issue with the job efficiency categorization. This issue
+did not affect any functionality in the 8.5 release, but resulted in incorrect
+values stored in the datawarehouse aggregate tables. These values are used by
+the new drill down function for Job Efficiency dashboard component and so must
+be updated to the correct values. If this reaggregation step is not run then
+the list of jobs in  the drilldown could include jobs that are not categorized
+as inefficient.
 
-The `modw_supremm.job` and `modw_supremm.job_error` table have extra columns to store metrics
-about job I/O. These columns are added to the tables by the upgrade script.
-
-See the [Configuration Guide](supremm-configuration.md#supremm_resourcesjson) for information
-about how to define the data mapping for the new I/O metrics.
-
-Changes to the mapping only affect the statistics for job data ingested after the configuration file
-is modified. The metrics for jobs that have already been ingested are not automatically
-updated. To update the data for existing jobs it is necessary to reset the job ingest
-status and then run the ingest and aggregation script.
-
-**If you do not update the data mapping then you do not need to perform the reset step (1)
-but the aggregation script in step (2) must always be run after an upgrade**
-
-Resetting the job ingest status and re-ingesting the data is done as follows:
-
-1) Reset the job ingest status for all jobs on each HPC resource:
-
-    $ /usr/lib64/xdmod/xdmod-supremm-admin --action reset --resource [RESOURCE] -d
-
-The amount of time this script takes depends on the number of jobs. In a test
-run for a resource that had approximately 2 million jobs it took approximately
-20 minutes to reset the status.
-
-2) Run the ingest and aggregation script:
-
-    $ aggregate_supremm.sh
-
-### Troubleshooting
-
-The `aggregate_supremm.sh` script has to be run after the upgrade script is run.
-If the aggregate script is not run then the error
+After the XDMoD upgrade procedure has completed the followgin command should
+be run:
+```bash
+/usr/share/xdmod/tools/etl/etl_overseer.php --last-modified-start-date 2000-01-01 -p jobefficiency.aggregation -p jobefficiency.joblist
 ```
-SQLSTATE[42S22]: Column not found: 1054 Unknown column 'jf.netdir_util_write' in 'where clause'
-```
-will be displayed in the XDMoD Usage tab and Metric Explorer tabs when trying to plot
-data for the SUPREMM realm.
+
+This will reaggregate all job efficiency data.

--- a/html/gui/js/modules/dashboard/JobEfficiencyComponent.js
+++ b/html/gui/js/modules/dashboard/JobEfficiencyComponent.js
@@ -149,7 +149,56 @@ XDMoD.Module.Dashboard.JobEfficiencyComponent = Ext.extend(CCR.xdmod.ui.Portlet,
             }),
             sm: new Ext.grid.RowSelectionModel({
                 singleSelect: true
-            })
+            }),
+            listeners: {
+                rowclick: function (panel, rowIndex) {
+                    var store = panel.getStore();
+                    var info = store.getAt(rowIndex);
+                    var config = JSON.parse(store.baseParams.config);
+
+                    var searchParams = {
+                        category: 2
+                    };
+                    searchParams[config.group_by] = info.id;
+
+                    var title = 'Inefficient jobs for user ' + info.data.name;
+                    var width = 480;
+                    var multiuser = false;
+
+                    if (config.group_by === 'pi') {
+                        multiuser = true;
+                        title = 'Inefficient jobs with PI ' + info.data.name;
+                        width = 600;
+                    }
+
+                    var rawdataWindow = new Ext.Window({
+                        height: 530,
+                        width: width,
+                        closable: true,
+                        modal: true,
+                        title: title,
+                        layout: 'fit',
+                        autoScroll: true,
+                        items: [{
+                            xtype: 'xdmod-jobgrid',
+                            height: 500,
+                            config: {
+                                realm: config.realm,
+                                job_viewer_realm: 'SUPREMM',
+                                start_date: config.start_date,
+                                end_date: config.end_date,
+                                params: searchParams,
+                                multiuser: multiuser,
+                                page_size: 15,
+                                row_click_callback: function () {
+                                    rawdataWindow.destroy();
+                                }
+                            }
+                        }]
+                    });
+                    rawdataWindow.show();
+                }
+            }
         }];
 
         if (this.config.multiuser) {


### PR DESCRIPTION
Clicking on a person/pi in the job efficiency component
now brings up a window that lists the jobs that were classified
as inefficient for the person/pi.

While implementing this feature two seperate bugs were found:
1) The aggregation query erronously omitted the job_category_id from the group by
   leading to incorrect values in the job_category_id column
2) The new json config in the group-by refactor had the wrong table name for the
   category groupby

these two bugs are fixed in this pull request because you need the changes
in this pull request to be able to confirm that the fixes work.
fixed at the same time since there was previously noway to test the bug

**This pull request depends on https://github.com/ubccr/xdmod/pull/1283 being merged.** 