### PR TITLE
Fix regression caused by groupby refactor changes

### DIFF
--- a/html/gui/js/modules/dashboard/UserJobEfficiencyComponent.js
+++ b/html/gui/js/modules/dashboard/UserJobEfficiencyComponent.js
@@ -60,7 +60,7 @@ XDMoD.Module.Dashboard.UserJobEfficiencyComponent = Ext.extend(CCR.xdmod.ui.Port
                         field: 'core_time_bad',
                         dirn: 'desc'
                     },
-                    statistics: ['core_time_bad', 'bad_core_ratio']
+                    statistics: ['core_time', 'core_time_bad', 'bad_core_ratio', 'job_count', 'job_count_bad', 'bad_job_ratio']
                 })
             },
             fields: [{


### PR DESCRIPTION
The new groupby refactor code requires all statistics to be explictly
specified. Previously there were a set of default stats that were added
automatically.

This change updates the component so all needed stats are explicitly
requested.