### PR TITLE
Improve test robustness

### DIFF
--- a/tests/automated_tests/test/specs/jobViewer.page.js
+++ b/tests/automated_tests/test/specs/jobViewer.page.js
@@ -129,7 +129,7 @@ class JobViewer {
         }
     }
     viewSaveJob(jobID, saveName) {
-        browser.waitAndClick(this.selectors.history.tree.jobnode(saveName, jobID));
+        browser.waitUntilAnimEndAndClick(this.selectors.history.tree.jobnode(saveName, jobID));
         browser.waitUntilAnimEnd(this.selectors.history.tree.jobnode(saveName, jobID) + '/ancestor::node()[3]//span[contains(text(),"Timeseries")]');
         browser.waitForExist(this.selectors.info.tabByName(jobID));
     }


### PR DESCRIPTION
We periodically get UI test failures. The most recent was the nightly
build failing due to timeouts clicking on the job in the tree.

requires #235 to pass