### PR TITLE
Make display of "Exit Status" filters deterministic.

### DIFF
--- a/etl/js/config/supremm/output_db/groupbys.json
+++ b/etl/js/config/supremm/output_db/groupbys.json
@@ -53,7 +53,7 @@
                 }
             ],
             "orderby": [
-                "id"
+                "name"
             ],
             "records": {
                 "id": "id",


### PR DESCRIPTION
The original code used the id value to sort the exit status filters.
Since the exit status is added to dynamically as value are ingested this
means that the sort order can vary between xdmod instances.

This changes it to use the name of the exit status so that the filter
order is determined by the sql collation.
