### PR TITLE
Remove unneeded keys, format consistency with xdmod

### DIFF
--- a/configuration/datawarehouse.d/ref/job-efficiency-group-bys.json
+++ b/configuration/datawarehouse.d/ref/job-efficiency-group-bys.json
@@ -1,115 +1,112 @@
 {
-  "category": {
-    "attribute_table": "job_category",
-    "attribute_table_schema": "modw_jobefficiency",
-    "attribute_to_aggregate_table_key_map": [
-      {
-        "id": "job_category_id"
-      }
-    ],
-    "attribute_values_query": {
-      "joins": [
-        {
-          "name": "job_category"
-        }
-      ],
-      "orderby": [
-        "id"
-      ],
-      "records": {
-        "id": "id",
-        "name": "description",
-        "order_id": "id",
-        "short_name": "description"
-      }
+    "category": {
+        "attribute_table_schema": "modw_jobefficiency",
+        "attribute_to_aggregate_table_key_map": [
+            {
+                "id": "job_category_id"
+            }
+        ],
+        "attribute_values_query": {
+            "joins": [
+                {
+                    "name": "job_category"
+                }
+            ],
+            "orderby": [
+                "id"
+            ],
+            "records": {
+                "id": "id",
+                "name": "description",
+                "order_id": "id",
+                "short_name": "description"
+            }
+        },
+        "category": "Administrative",
+        "description_html": "Organizations that have users with allocations.",
+        "name": "Category"
     },
-    "category": "Administrative",
-    "description_html": "Organizations that have users with allocations.",
-    "name": "Category"
-  },
-  "none": {
-    "$ref-with-overwrite": "datawarehouse.d/ref/group-by-none.json",
-    "$overwrite": {
-      "name": "${REALM_NAME}",
-      "description_html": "Summarizes job performance data obtained via the SUPReMM project. These data are obtained from performance monitoring software running on each HPC resource. For most resources this data is generated for both XSEDE and non-XSEDE jobs. Non-XSEDE jobs can be filtered using a filter on the \"Grant Type\"."
-    }
-  },
-  "day": {
-    "$ref": "datawarehouse.d/ref/group-by-time-period.json#/day"
-  },
-  "person": {
-    "$ref": "datawarehouse.d/ref/group-by-common.json#/person"
-  },
-  "pi": {
-    "attribute_table": "piperson",
-    "attribute_table_schema": "modw",
-    "attribute_to_aggregate_table_key_map": [
-      {
-        "person_id": "principalinvestigator_person_id"
-      }
-    ],
-    "attribute_values_query": {
-      "joins": [
-        {
-          "name": "piperson"
-        }
-      ],
-      "orderby": [
-        "order_id"
-      ],
-      "records": {
-        "id": "person_id",
-        "name": "long_name",
-        "order_id": "order_id",
-        "short_name": "short_name"
-      }
+    "day": {
+        "$ref": "datawarehouse.d/ref/group-by-time-period.json#/day"
     },
-    "category": "Administrative",
-    "description_html": "The principal investigator of a project has a valid allocation, which can be used by him/her or the members of the project to run jobs on.",
-    "name": "PI"
-  },
-  "provider": {
-        "$ref-with-overwrite": "datawarehouse.d/ref/group-by-common.json#/provider",
+    "institution": {
+        "attribute_table_schema": "modw",
+        "attribute_to_aggregate_table_key_map": [
+            {
+                "id": "person_organization_id"
+            }
+        ],
+        "attribute_values_query": {
+            "joins": [
+                {
+                    "name": "organization"
+                }
+            ],
+            "orderby": [
+                "id"
+            ],
+            "records": {
+                "id": "id",
+                "name": "long_name",
+                "order_id": "id",
+                "short_name": "short_name"
+            }
+        },
+        "category": "Administrative",
+        "chart_options": {
+            "dataset_display_type": {
+                "aggregate": "datasheet"
+            },
+            "dataset_type": "aggregate"
+        },
+        "description_html": "Organizations that have users with allocations.",
+        "name": "User Institution"
+    },
+    "none": {
+        "$overwrite": {
+            "description_html": "Summarizes job performance data obtained via the SUPReMM project. These data are obtained from performance monitoring software running on each HPC resource. For most resources this data is generated for both XSEDE and non-XSEDE jobs. Non-XSEDE jobs can be filtered using a filter on the \"Grant Type\".",
+            "name": "${REALM_NAME}"
+        },
+        "$ref-with-overwrite": "datawarehouse.d/ref/group-by-none.json"
+    },
+    "person": {
+        "$ref": "datawarehouse.d/ref/group-by-common.json#/person"
+    },
+    "pi": {
+        "attribute_table_schema": "modw",
+        "attribute_to_aggregate_table_key_map": [
+            {
+                "person_id": "principalinvestigator_person_id"
+            }
+        ],
+        "attribute_values_query": {
+            "joins": [
+                {
+                    "name": "piperson"
+                }
+            ],
+            "orderby": [
+                "order_id"
+            ],
+            "records": {
+                "id": "person_id",
+                "name": "long_name",
+                "order_id": "order_id",
+                "short_name": "short_name"
+            }
+        },
+        "category": "Administrative",
+        "description_html": "The principal investigator of a project has a valid allocation, which can be used by him/her or the members of the project to run jobs on.",
+        "name": "PI"
+    },
+    "provider": {
         "$overwrite": {
             "attribute_to_aggregate_table_key_map": [
                 {
                     "organization_id": "organization_id"
                 }
             ]
-        }
-  },
- "institution": {
-    "attribute_table": "organization",
-    "attribute_table_schema": "modw",
-    "attribute_to_aggregate_table_key_map": [
-      {
-        "id": "person_organization_id"
-      }
-    ],
-    "attribute_values_query": {
-      "joins": [
-        {
-          "name": "organization"
-        }
-      ],
-      "orderby": [
-        "id"
-      ],
-      "records": {
-        "id": "id",
-        "name": "long_name",
-        "order_id": "id",
-        "short_name": "short_name"
-      }
-    },
-    "category": "Administrative",
-    "chart_options": {
-      "dataset_display_type": {
-        "aggregate": "datasheet"
-      },
-      "dataset_type": "aggregate"
-    },
-    "description_html": "Organizations that have users with allocations.",
-    "name": "User Institution"
-  }
+        },
+        "$ref-with-overwrite": "datawarehouse.d/ref/group-by-common.json#/provider"
+    }
 }

--- a/etl/js/config/supremm/output_db/groupbys.json
+++ b/etl/js/config/supremm/output_db/groupbys.json
@@ -1,6 +1,5 @@
 {
     "application": {
-        "attribute_table": "application",
         "attribute_table_schema": "modw_supremm",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -39,7 +38,6 @@
         "$ref": "datawarehouse.d/ref/group-by-time-period.json#/day"
     },
     "exit_status": {
-        "attribute_table": "exit_status",
         "attribute_table_schema": "modw_supremm",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -76,7 +74,6 @@
         "$ref": "datawarehouse.d/ref/group-by-hierarchy.json#/fieldofscience"
     },
     "granted_pe": {
-        "attribute_table": "granted_pe",
         "attribute_table_schema": "modw_supremm",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -109,7 +106,6 @@
         "name": "Granted Processing Element"
     },
     "institution": {
-        "attribute_table": "organization",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -201,7 +197,6 @@
         "$ref": "datawarehouse.d/ref/group-by-common.json#/pi"
     },
     "pi_institution": {
-        "attribute_table": "organization",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -255,7 +250,6 @@
                 "operation": "="
             }
         ],
-        "attribute_table": "queue",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -263,7 +257,6 @@
             }
         ],
         "attribute_values_query": {
-            "query_hint": "DISTINCT",
             "joins": [
                 {
                     "name": "queue"
@@ -272,6 +265,7 @@
             "orderby": [
                 "id"
             ],
+            "query_hint": "DISTINCT",
             "records": {
                 "id": "id",
                 "name": "id",
@@ -289,7 +283,15 @@
         "name": "Queue"
     },
     "resource": {
-        "attribute_table": "resourcefact",
+        "additional_join_constraints": [
+            {
+                "attribute_table": "resourcefact",
+                "attribute_expr": "id",
+                "operation": "=",
+                "aggregate_table": "resourcespecs",
+                "aggregate_expr": "resource_id"
+            }
+        ],
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -332,7 +334,6 @@
         "name": "Resource"
     },
     "shared": {
-        "attribute_table": "shared",
         "attribute_table_schema": "modw_supremm",
         "attribute_to_aggregate_table_key_map": [
             {


### PR DESCRIPTION
remove the `attribute_table` as it is not needed after https://github.com/ubccr/xdmod/pull/1288
This will fail until that is merged

This also formats according to "standards" by having 4 spaces and orders the keys alphabetically