### PR TITLE
Add ability to disable the analyze table step from the aggregate_supremm.sh script

### DIFF
--- a/bin/aggregate_supremm.sh
+++ b/bin/aggregate_supremm.sh
@@ -11,12 +11,37 @@ reportfail()
     exit 1
 }
 
-if [ "$1" = "-d" ];
-then
-    FLAGS="-d"
-else
-    FLAGS="-q"
-fi
+usage()
+{
+    echo "Usage: $0 [OPTION]..."
+    echo "  -h      Display this help message."
+    echo "  -d      Enable debug log output."
+    echo "  -a (true|false) Whether to enable or disable the analyse table"
+    echo "          step after aggregation."
+}
+
+FLAGS="-q"
+AGG_FLAGS=""
+
+while getopts "hda:" option; do
+    case "$option" in
+        a)
+            if [[ "${OPTARG}" = "false" ]];
+	    then
+                AGG_FLAGS='--analyze-tables false'
+            fi
+            ;;
+        d)
+            FLAGS="-d"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
 
 (
     flock -n 9 || reportfail
@@ -27,7 +52,7 @@ fi
     
     php ${XDMOD_LIB_PATH}/supremm_sharedjobs.php $FLAGS
     
-    php ${XDMOD_LIB_PATH}/aggregate_supremm.php $FLAGS
+    php ${XDMOD_LIB_PATH}/aggregate_supremm.php $FLAGS $AGG_FLAGS
 
     ${XDMOD_BIN_PATH}/xdmod-build-filter-lists --realm SUPREMM $FLAGS
 ) 9>${LOCKFILE}


### PR DESCRIPTION
The job performance data aggregation step runs the mysql analyze tables
command by default after aggregation. This command can take a long time
to run and the XDMoD user interface is unavailable while the commmand is
running. This change updates the top level aggregate_supremm.sh to add
a command line flag to disable the analyze table step.

It is recommended that the analyze tables command should be run periodically
but does not need to be run every day. At CCR the anaylze tables step is run
once per week on a weekend day.