### PR TITLE
Handle case where ingest/aggregation takes a long time and DB conn timeout.

### DIFF
--- a/classes/DB/EtlJournalHelper.php
+++ b/classes/DB/EtlJournalHelper.php
@@ -43,6 +43,8 @@ class EtlJournalHelper
             array($this->schema . '.' . $this->table)
         );
 
+        $this->dwdb->disconnect();
+
         if (count($lastRunInfo) > 0) {
             $this->lastModified = $lastRunInfo[0]['last_modified'];
         }
@@ -69,5 +71,7 @@ class EtlJournalHelper
                 $process_end_time
             )
         );
+
+        $this->dwdb->disconnect();
     }
 }


### PR DESCRIPTION
If the ingest or aggregation step takes a long time then the database
connection in the Journal Helper times out and the journal entry
does not get written.

This change explicity closes the database connection after each read/write.
The code will automatically open a new connection when needed. The other
possible change would have been to catch the server-has-gone-away exception and
retry (which is what I've done for the logger).  In this case the usage pattern
is well known: the helper needs to access the database once at the start and
once at the end and not in the middle so there is no need to keep an idle
connection open.

This was tested by changing the `/etc/my.cnf.d/server.cnf` file in a
docker instance and adding the following:

```ini
wait_timeout = 30
```

I then put a `sleep(60)` as the last line of the getLastModified() function. Then ran /usr/lib64/xdmod/aggregate_supremm.php. I also had the fix for the logger timeout installed too.