### PR TITLE
Updating Resource GroupBys Underlying SQL

### DIFF
--- a/etl/js/config/supremm/output_db/groupbys.json
+++ b/etl/js/config/supremm/output_db/groupbys.json
@@ -299,7 +299,7 @@
                 {
                     "alias": "rs",
                     "name": "resourcespecs",
-                    "on": "rf.id = rs.resource_id"
+                    "on": "rf.id = rs.resource_id AND rs.end_date_ts IS NULL"
                 }
             ],
             "orderby": [


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an additional ON clause to the `resourcespecs` join that specifies that only rows with a null `end_date_ts` ( the current resourcespec for a given resourcefact ) should be included. 

## Motivation and Context
There was a visual bug present when adding a Resource filter for SUPREMM data
where multiple instances of the same resource name would be present in the chart
subtitle. This was caused by the underlying SQL joining `resourcefact` to
`resourcespecs` which is a one (resourcefact) -> many (resourcespecs)
relationship. This is due to resourcespecs being a historical table that
captures the change over time that a resource goes through. The most current
spec for a resource is identified by the one that has a null `end_date_ts`
value.

## Tests performed
Manual testing was performed 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
