### PR TITLE
Add GPU information.

### DIFF
--- a/configuration/etl/etl.d/supremm-migration-9_5_0-10_0_0.json
+++ b/configuration/etl/etl.d/supremm-migration-9_5_0-10_0_0.json
@@ -13,5 +13,16 @@
         }
     },
     "migration-9_5_0-10_0_0": [
+        {
+            "name": "table-create",
+            "description": "Setup tables",
+            "class": "ManageTables",
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "definition_file_list": [
+                "supremm/job.json",
+                "supremm/job_errors.json"
+            ]
+        }
     ]
 }

--- a/docs/supremm-upgrade.md
+++ b/docs/supremm-upgrade.md
@@ -13,3 +13,32 @@ upgraded.
 
 9.5.0 to 10.0.0 Upgrade Notes
 ----------------------------
+
+- This upgrade includes database schema changes.
+    - Modifies `modw_supremm` schema.
+    - Modifies `modw_aggregates` schema.
+
+This upgrade adds a new dimension to the SUPReMM realm to allow filtering on
+overall GPU usage and new statistics for GPU-hour weighted average GPU usage
+and GPU hours.
+
+The upgrade script `xdmod-upgrade` will modify the fact tables in the database
+to add columns to store the new GPU information. After the `xdmod-upgrade` script
+completes, the ingestion and aggregation script `aggregate_supremm.sh` **must**
+be run. If the `aggregate_supremm.sh` script has not been run then the portal will display
+an error message similar to the one below when trying to view SUPReMM realm data:
+```
+SQLSTATE[42S22]: Column not found: 1054 Unknown column 'gpu_time_active' in 'where clause'
+```
+
+ Existing GPU jobs in the database will **not** automatically be re-ingested by the
+upgrade scripts. So jobs that were already loaded into XDMoD will show as no GPU
+information. You can force reingestion of all jobs by resetting the job
+ingest status:
+```
+$ /usr/lib64/xdmod/xdmod-supremm-admin --action reset --resource [RESOURCE] -d
+```
+And then run the ingest and aggregation script:
+```
+$ aggregate_supremm.sh
+```

--- a/etl/js/.eslintrc.json
+++ b/etl/js/.eslintrc.json
@@ -6,6 +6,7 @@
         "ecmaVersion": 6
     },
     "rules": {
-        "no-console": 0
+        "no-console": 0,
+        "no-bitwise": 0
     }
 }

--- a/tests/integration_tests/lib/Controllers/UserInterfaceControllerTest.php
+++ b/tests/integration_tests/lib/Controllers/UserInterfaceControllerTest.php
@@ -125,6 +125,11 @@ class UserInterfaceControllerTest extends \PHPUnit_Framework_TestCase
             'label' => 'GPU0 Usage Value'
         ),
 
+        'gpu_usage_bucketid' => array(
+            'defaultChartSettings' => '0',
+            'label' => 'GPU Active Value'
+        ),
+
         'granted_pe' => array(
             'defaultChartSettings' => '2',
             'label' => 'Granted Processing Element'
@@ -224,6 +229,7 @@ class UserInterfaceControllerTest extends \PHPUnit_Framework_TestCase
             'avg_percent_cpu_idle' => 'Avg CPU %: Idle: weighted by core-hour',
             'avg_percent_cpu_system' => 'Avg CPU %: System: weighted by core-hour',
             'avg_percent_cpu_user' => 'Avg CPU %: User: weighted by core-hour',
+            'avg_percent_gpu_active' => 'Avg GPU active: weighted by gpu-hour',
             'avg_percent_gpu0_nv_utilization' => 'Avg GPU0 usage: weighted by node-hour',
             'avg_netdir_home_write' => 'Avg: /home write rate: Per Node weighted by node-hour',
             'avg_netdir_projects_write' => 'Avg: /projects write rate: Per Node weighted by node-hour',
@@ -255,6 +261,8 @@ class UserInterfaceControllerTest extends \PHPUnit_Framework_TestCase
             'cpu_time_system' => 'CPU Hours: System: Total',
             'wall_time' => 'CPU Hours: Total',
             'cpu_time_user' => 'CPU Hours: User: Total',
+            'gpu_time_active' => 'GPU Hours Active: Total',
+            'gpu_time' => 'GPU Hours: Total',
             'gpu0_nv_utilization' => 'GPU0 Hours: Total',
             'job_count' => 'Number of Jobs Ended',
             'running_job_count' => 'Number of Jobs Running',

--- a/tests/integration_tests/lib/REST/Warehouse/JobViewerTest.php
+++ b/tests/integration_tests/lib/REST/Warehouse/JobViewerTest.php
@@ -23,6 +23,7 @@ class JobViewerTest extends \PHPUnit_Framework_TestCase
             "exit_status",
             "fieldofscience",
             "gpu0_nv_utilization_bucketid",
+            "gpu_usage_bucketid",
             "granted_pe",
             "ibrxbyterate_bucket_id",
             "institution",

--- a/tests/integration_tests/scripts/validate.sh
+++ b/tests/integration_tests/scripts/validate.sh
@@ -48,6 +48,9 @@ checkForColumn netdir_projects_read
 checkForColumn netdir_projects_write
 checkForColumn netdir_util_read
 checkForColumn netdir_util_write
+checkForColumn gpus
+checkForColumn gpu_time
+checkForColumn gpu_usage
 
 # Check that the jobhosts table has end_time_ts column with non-zero timestamps
 jobcount=$(echo 'SELECT COUNT(*) FROM modw_supremm.job j, modw_supremm.jobhost jh WHERE j.resource_id = jh.resource_id AND j.local_job_id = jh.local_job_id AND j.end_time_ts = jh.end_time_ts' | mysql -N modw_supremm)


### PR DESCRIPTION
Add extra GPU groupby and statistics. This adds:
- GPU Hours Active: Total
- GPU Hours: Total

statistics and "GPU Active" group by. These use the total GPU time / utilization for the job (c.f. the other GPU metrics that default to just GPU device 0).
