### PR TITLE
Add the end_time of the job to the lookup for tg_job_id

### DIFF
--- a/etl/js/config/supremm/etl.schema.js
+++ b/etl/js/config/supremm/etl.schema.js
@@ -2241,7 +2241,7 @@ module.exports = {
             },
             table: 'modw.job_tasks jt, modw.job_records jr',
             // bind these using the same query format function just replace with attributes.:resource_id.value
-            where: 'jt.resource_id = :resource_id and jt.local_job_id_raw = :local_job_id and jt.job_record_id = jr.job_record_id',
+            where: 'jt.resource_id = :resource_id and jt.local_job_id_raw = :local_job_id and jt.end_time_ts = :end_time_ts AND jt.job_record_id = jr.job_record_id',
             cacheable: false
         },
         account: {


### PR DESCRIPTION
This is a redo of #284 on the xdmod 10.0 branch.

There is a missing where condition on the lookup that matches a job in the supremm realm to the jobs realm. In the event that job identifiers get reused by the resource manager and there is more than one job with the same job identifier then the information about the job in the supremm realm may be incorrectly mapped to the wrong job (with the same identifier) but that ran at a different time.
