### PR TITLE
Add wall_time_total to supremm statistics.

### DIFF
--- a/etl/js/config/supremm/etl.schema.js
+++ b/etl/js/config/supremm/etl.schema.js
@@ -658,6 +658,14 @@ module.exports = {
                             +	 '<i>Core Time:</i> defined as the time between start and end time of execution for a particular job times the number of allocated cores.',
                     decimals: 0
                 }, {
+                    name: 'wall_time_total',
+                    sql: 'COALESCE(SUM(jf.wall_time/3600), 0)',
+                    label: 'Wall Hours: Total',
+                    unit: 'Hour',
+                    description: 'The total time, in hours, jobs took to execute.<br/>'
+                            +	 '<i>Wall Time:</i> Wall time is defined as the linear time between start and end time of execution for a particular job.',
+                    decimals: 0
+                }, {
                     name: 'wall_time_per_job',
                     aggregate_sql: 'COALESCE(SUM(jf.wall_time)/SUM(CASE ${DATE_TABLE_ID_FIELD} WHEN ${MIN_DATE_ID} THEN jf.running_job_count ELSE jf.started_job_count END),0)/3600.0',
                     timeseries_sql: 'COALESCE(SUM(jf.wall_time)/SUM(jf.running_job_count),0)/3600.0',

--- a/tests/integration_tests/lib/Controllers/UserInterfaceControllerTest.php
+++ b/tests/integration_tests/lib/Controllers/UserInterfaceControllerTest.php
@@ -271,6 +271,7 @@ class UserInterfaceControllerTest extends \PHPUnit_Framework_TestCase
             'wait_time_per_job' => 'Wait Hours: Per Job',
             'wait_time' => 'Wait Hours: Total',
             'wall_time_per_job' => 'Wall Hours: Per Job',
+            'wall_time_total' => 'Wall Hours: Total',
             'requested_wall_time_per_job' => 'Wall Hours: Requested: Per Job',
             'requested_wall_time' => 'Wall Hours: Requested: Total'
         );


### PR DESCRIPTION
## Description
Adds a new statistic for showing total wall time to the SUPREMM realm. 

## Motivation and Context
Need this statistic for the Wall Time Accuracy analytic in the new efficiency tab. 

## Tests performed
Tested on metrics-dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
