### PR TITLE
Add distinct clause to the query for resource groupby.

### DIFF
--- a/etl/js/config/supremm/output_db/groupbys.json
+++ b/etl/js/config/supremm/output_db/groupbys.json
@@ -339,6 +339,7 @@
                     "on": "rf.id = rs.resource_id"
                 }
             ],
+            "query_hint": "DISTINCT",
             "orderby": [
                 "rf.code",
                 "rf.name"


### PR DESCRIPTION
I assume that this was an oversight from the groupby refactor.
The original code had the distinct clause in it. See e.g.:

https://github.com/ubccr/xdmod-supremm/blob/xdmod7.1/etl/js/config/supremm/output_db/Query/SUPREMM/GroupBys/GroupByResource.php#L28

This fixes issue:

https://app.asana.com/0/1200028182662861/1201687182483666

