### PR TITLE
Change the default duration for efficiency tab toolbar.

### DIFF
--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -12,7 +12,12 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
     // Portal Module Toolbar Config
     usesToolbar: true,
     toolbarItems: {
-        durationSelector: true
+        durationSelector: {
+            enable: true,
+            config: {
+                defaultCannedDateIndex: 2
+            }
+        }
     },
 
     initComponent: function () {


### PR DESCRIPTION
## Description
Updated default duration in efficiency tab toolbar from previous month to 30 days. 

## Motivation and Context
This fixes issue: 
https://app.asana.com/0/1200028182662861/1201687182483692/f

## Tests performed
Tested change on metrics-dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
