### PR TITLE
Fix bugs with displaying raw data on efficiency tab drill down plot.

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/RawData.php
+++ b/classes/DataWarehouse/Query/SUPREMM/RawData.php
@@ -59,6 +59,7 @@ class RawData extends \DataWarehouse\Query\Query implements \DataWarehouse\Query
 													new TableField($personTable,"id") ));
 
 		$this->addField(new TableField($resourcefactTable,"code", 'resource'));
+        $this->addField(new TableField($resourcefactTable, "timezone"));
 		$this->addField(new TableField($personTable, "long_name", "name"));
 
         $this->addField( new TableField($factTable, "_id", "jobid") );

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -978,7 +978,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                 { name: 'jobid', mapping: 'jobid', type: 'int' },
                 { name: 'local_job_id', mapping: 'local_job_id', type: 'int' },
                 { name: 'start_time_ts', mapping: 'start_time_ts', type: 'int' },
-                { name: 'timezone', mapping: 'timezone', type: 'int' },
+                { name: 'timezone', mapping: 'timezone', type: 'string' },
                 { name: 'cpu_user', mapping: 'cpu_user', type: 'string' },
                 { name: 'gpu_usage', mapping: 'gpu_usage', type: 'int' },
                 { name: 'max_memory', mapping: 'max_memory', type: 'int' },

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -978,6 +978,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                 { name: 'jobid', mapping: 'jobid', type: 'int' },
                 { name: 'local_job_id', mapping: 'local_job_id', type: 'int' },
                 { name: 'start_time_ts', mapping: 'start_time_ts', type: 'int' },
+                { name: 'timezone', mapping: 'timezone', type: 'int' },
                 { name: 'cpu_user', mapping: 'cpu_user', type: 'string' },
                 { name: 'gpu_usage', mapping: 'gpu_usage', type: 'int' },
                 { name: 'max_memory', mapping: 'max_memory', type: 'int' },
@@ -1025,7 +1026,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                     dataIndex: 'catastrophe',
                     header: 'Catastrophe',
                     renderer: function (value, p, r) {
-                        return (Number(r.json.catastrophe));
+                        return (Number(r.json.catastrophe) * 100).toFixed(5);
                     }
                 };
                 break;
@@ -1057,12 +1058,12 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                     menuDisabled: true
                 },
                 columns: [{
-                    width: 175,
                     id: 'start_time_ts',
                     dataIndex: 'start_time_ts',
                     header: 'Start Time',
-                    renderer: function (value) {
-                        return new Date(value * 1000);
+                    width: 140,
+                    renderer: function (value, p, r) {
+                        return moment.tz(value * 1000, r.json.timezone).format('Y-MM-DD HH:mm:ss z');
                     }
                 }, {
                     id: 'raw_data_username',
@@ -1111,7 +1112,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
         var rawData = new Ext.Window({
             id: 'raw_data_window',
             height: 510,
-            width: 480,
+            width: 500,
             closable: true,
             border: false,
             modal: true,


### PR DESCRIPTION
## Description
These changes fix how the raw data is displayed when you view the data on the efficiency tab from the drill down plot. The timezone of the resource is used for displaying start time of the jobs shown. The formatting for start time string was updated to use momentjs library, the formatting for the raw data shown for homogeneity analytic was changed to round the value, and the width of columns and window were updated as needed to show all raw data in one window without any values being cut off.

## Motivation and Context
Fixed this issue: 
https://app.asana.com/0/1200028182662861/1201687995403789/f

## Tests performed
Tested on metrics-dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
