### PR TITLE
Fixes bugs with tooltip display on charts in efficiency tab.

### DIFF
--- a/classes/Rest/Controllers/EfficiencyControllerProvider.php
+++ b/classes/Rest/Controllers/EfficiencyControllerProvider.php
@@ -399,7 +399,7 @@ class EfficiencyControllerProvider extends BaseControllerProvider
 
             foreach ($buckets as $bucket) {
                 if (array_search($bucket['id'], array_column($drillDowns, 'id'), true) === false) {
-                    $chartData[] = ['y' => 0, 'drilldown' => array('id' => $bucket['id'], 'label' => $bucket['name'])];
+                    $chartData[] = ['y' => 0, 'drilldown' => array('id' => $bucket['id'], 'label' => $bucket['label'])];
                 }
             }
 
@@ -523,9 +523,7 @@ class EfficiencyControllerProvider extends BaseControllerProvider
         // Change the name key for each dimension value to "long_name".
         $dimensionValuesData = $dimensionValues['data'];
         foreach ($dimensionValuesData as &$dimensionValue) {
-            $dimensionValue['long_name'] = html_entity_decode($dimensionValue['name']);
-            $dimensionValue['name'] = $dimensionValue['long_name'];
-            $dimensionValue['short_name'] = html_entity_decode($dimensionValue['short_name']);
+            $dimensionValue['label'] = $dimensionValue['short_name'];
         }
 
         // Return the found dimension values.

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -56,13 +56,14 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                         return 'User (Access denied to view name) <br>' + self.config.statisticLabels[0] + ': <b>' + this.point.x.toFixed(0) + ' ' + self.config.valueLabels[0] + '</b><br>' + self.config.statisticLabels[1] + ': <b>' + this.point.y.toFixed(0) + ' ' + self.config.valueLabels[1] + '</b>';
                     },
                     positioner: function (labelWidth, labelHeight, point) {
-                        var tooltipX, tooltipY;
+                        var tooltipX;
+                        var tooltipY;
                         if (point.plotX + labelWidth > self.chart.plotWidth) {
-                            tooltipX = point.plotX + self.chart.plotLeft - labelWidth - 20;
+                            tooltipX = (point.plotX + self.chart.plotLeft) - (labelWidth - 20);
                         } else {
                             tooltipX = point.plotX + self.chart.plotLeft + 20;
                         }
-                        tooltipY = point.plotY + self.chart.plotTop - 20;
+                        tooltipY = (point.plotY + self.chart.plotTop) - 20;
                         return {
                             x: tooltipX,
                             y: tooltipY

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -56,15 +56,13 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                         return 'User (Access denied to view name) <br>' + self.config.statisticLabels[0] + ': <b>' + this.point.x.toFixed(0) + ' ' + self.config.valueLabels[0] + '</b><br>' + self.config.statisticLabels[1] + ': <b>' + this.point.y.toFixed(0) + ' ' + self.config.valueLabels[1] + '</b>';
                     },
                     positioner: function (labelWidth, labelHeight, point) {
-                        var tooltipX;
-                        var tooltipY;
-                        if (point.plotX < self.chart.plotWidth / 2) {
-                            tooltipX = point.plotX + 300;
-                        } else if (point.plotX > 50) {
-                            tooltipX = point.plotX - 50;
+                        var tooltipX, tooltipY;
+                        if (point.plotX + labelWidth > self.chart.plotWidth) {
+                            tooltipX = point.plotX + self.chart.plotLeft - labelWidth - 20;
+                        } else {
+                            tooltipX = point.plotX + self.chart.plotLeft + 20;
                         }
-
-                        tooltipY = point.plotY + 25;
+                        tooltipY = point.plotY + self.chart.plotTop - 20;
                         return {
                             x: tooltipX,
                             y: tooltipY


### PR DESCRIPTION
## Description
This fixes two bugs related to the tooltips not displaying correctly on efficiency tab charts. One fix includes adding code that returns the correct label string to be used for the categories in the drill down histogram plot. The other fix updates the tooltip positioner on the scatter plot so that the entire tooltip is visible for each point in the plot. 

## Motivation and Context
Fixes these issues: 
https://app.asana.com/0/1200028182662861/1201689083643968/f
https://app.asana.com/0/1200028182662861/1201687995403781/f

## Tests performed
Tested on metrics-dev. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
