### PR TITLE
Change sizing of scatter and drill down charts in efficiency tab.

### DIFF
--- a/html/gui/js/modules/efficiency/AnalyticPanel.js
+++ b/html/gui/js/modules/efficiency/AnalyticPanel.js
@@ -37,7 +37,6 @@ XDMoD.Module.Efficiency.AnalyticPanel = Ext.extend(Ext.Panel, {
             layout: 'card',
             activeItem: 0,
             split: true,
-            autoScroll: true,
             region: 'center',
             border: false,
             items: [
@@ -45,8 +44,6 @@ XDMoD.Module.Efficiency.AnalyticPanel = Ext.extend(Ext.Panel, {
                     id: 'analytic_scatter_plot_' + self.config.analytic,
                     config: self.config,
                     border: false,
-                    boxMinWidth: 800,
-                    boxMinHeight: 600,
                     autoScroll: true,
                     panelSettings: {
                         url: XDMoD.REST.url + '/efficiency/scatterPlot/' + self.config.analytic,

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -803,7 +803,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                             // Update arrow size based on new chart dimensions
                             this.chart.xAxis[1].update({
                                 title: {
-                                    text: "<img src='gui/images/right_arrow.png' class='" + cls + "' style='width: " + (adjWidth* (2 / 3)) + "px; height: 100px;' />"
+                                    text: "<img src='gui/images/right_arrow.png' class='" + cls + "' style='width: " + (adjWidth * (2 / 3)) + "px; height: 100px;' />"
                                 }
                             });
                             this.chart.yAxis[1].update({

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -28,7 +28,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                 colors: ['#2f7ed8', '#0d233a', '#8bbc21', '#910000', '#1aadce', '#492970', '#f28f43', '#77a1e5', '#c42525', '#a6c96a'],
                 title:
                 {
-                    x: 130,
+                    x: 100,
                     style: {
                         color: '#444b6e',
                         fontSize: 20
@@ -36,7 +36,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                     text: self.config.analytic
                 },
                 subtitle: {
-                    x: 130
+                    x: 100
                 },
                 loading: {
                     style: {
@@ -768,7 +768,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
             autoScroll: true,
             baseChartOptions: {
                 chart: {
-                    marginLeft: 200
+                    marginLeft: 175
                 },
                 plotOptions: {
                     series: {

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -197,6 +197,8 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
             };
 
             var chartOptions = jQuery.extend(true, {}, defaultChartSettings, self.chartSettings);
+            chartOptions.chart.width = Math.max(600, self.getWidth());
+            chartOptions.chart.height = Math.max(400, self.getHeight());
 
             self.chart = new Highcharts.Chart(chartOptions);
         };
@@ -412,7 +414,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
             listeners: {
                 resize: function () {
                     if (self.chart) {
-                        self.chart.reflow();
+                        self.chart.setSize(Math.max(600, self.getWidth()), Math.max(400, self.getHeight()));
                         // Update arrow size based on new chart dimensions
                         self.chart.xAxis[1].update({
                             title: {
@@ -759,59 +761,65 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
             }
         });
 
-        var personChart = new CCR.xdmod.ui.HighChartPanel({
-            id: 'hc-panel-' + self.config.analytic,
-            person: person,
-            personId: personId,
-            boxMinWidth: 800,
-            boxMinHeight: 600,
+        var drilldownChartContainer = new Ext.Panel({
+            layout: 'fit',
+            border: false,
             autoScroll: true,
-            baseChartOptions: {
-                chart: {
-                    marginLeft: 175
-                },
-                plotOptions: {
-                    series: {
-                        events: {
-                            click: function (e) {
-                                var dataPoint = e.point.index;
-                                var datasetId = e.point.series.userOptions.datasetId;
-                                var drilldownId = e.point.drilldown.id;
-                                var drilldownLabel = e.point.drilldown.label;
-                                var jobGrid = Ext.getCmp('cpu_user_job_information');
+            items: [
+                new CCR.xdmod.ui.HighChartPanel({
+                id: 'hc-panel-' + self.config.analytic,
+                person: person,
+                personId: personId,
+                boxMinWidth: 600,
+                boxMinHeight: 400,
+                baseChartOptions: {
+                    chart: {
+                        marginLeft: 175
+                    },
+                    plotOptions: {
+                        series: {
+                            events: {
+                                click: function (e) {
+                                    var dataPoint = e.point.index;
+                                    var datasetId = e.point.series.userOptions.datasetId;
+                                    var drilldownId = e.point.drilldown.id;
+                                    var drilldownLabel = e.point.drilldown.label;
+                                    var jobGrid = Ext.getCmp('cpu_user_job_information');
 
-                                if (jobGrid) {
-                                    jobGrid.destroy();
+                                    if (jobGrid) {
+                                        jobGrid.destroy();
+                                    }
+
+                                    self.getJobList(personId, person, dataPoint, datasetId, drilldownId, drilldownLabel);
                                 }
-
-                                self.getJobList(personId, person, dataPoint, datasetId, drilldownId, drilldownLabel);
                             }
                         }
                     }
-                }
-            },
-            store: chartStore,
-            listeners: {
-                resize: function () {
-                    if (personChart.chart.xAxis[1]) {
-                        // Update arrow size based on new chart dimensions
-                        personChart.chart.xAxis[1].update({
-                            title: {
-                                text: "<img src='gui/images/right_arrow.png' class='" + cls + "' style='width: " + (personChart.chart.plotWidth * (2 / 3)) + "px; height: 100px;' />"
-                            }
-                        });
-                        personChart.chart.yAxis[1].update({
-                            title: {
-                                text: "<img src='gui/images/right_arrow.png' style='width: " + (personChart.chart.plotHeight * (2 / 3)) + "px; height: 100px;' />"
-                            }
-                        });
+                },
+                store: chartStore,
+                listeners: {
+                    resize: function (t, adjWidth, adjHeight, rawWidth, rawHeight) {
+                        if (this.chart.xAxis[1]) {
+                            // Update arrow size based on new chart dimensions
+                            this.chart.xAxis[1].update({
+                                title: {
+                                    text: "<img src='gui/images/right_arrow.png' class='" + cls + "' style='width: " + (adjWidth* (2 / 3)) + "px; height: 100px;' />"
+                                }
+                            });
+                            this.chart.yAxis[1].update({
+                                title: {
+                                    text: "<img src='gui/images/right_arrow.png' style='width: " + (adjHeight * (2 / 3)) + "px; height: 100px;' />"
+                                }
+                            });
+                        }
                     }
                 }
-            }
+                })
+            ]
         });
 
         var analyticPanel = Ext.getCmp('detailed_analytic_panel_' + this.config.analytic);
-        analyticPanel.add(personChart);
+        analyticPanel.add(drilldownChartContainer);
         analyticPanel.layout.setActiveItem(1);
         analyticPanel.doLayout();
     },

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -22,7 +22,8 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                 chart: {
                     renderTo: self.id + 'ScatterPlot',
                     type: 'scatter',
-                    zoomType: 'xy'
+                    zoomType: 'xy',
+                    marginLeft: 200
                 },
                 colors: ['#2f7ed8', '#0d233a', '#8bbc21', '#910000', '#1aadce', '#492970', '#f28f43', '#77a1e5', '#c42525', '#a6c96a'],
                 title:
@@ -766,6 +767,9 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
             boxMinHeight: 600,
             autoScroll: true,
             baseChartOptions: {
+                chart: {
+                    marginLeft: 200
+                },
                 plotOptions: {
                     series: {
                         events: {


### PR DESCRIPTION
## Description
This change removes the unused white space to the left of the charts in the efficiency tab. 

## Motivation and Context
Fixes this issue: 
https://app.asana.com/0/1200028182662861/1201687182483670/f

## Tests performed
Tested on metrics-dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
