### PR TITLE
Update version of nodejs to the current LTS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,10 @@ jobs:
           command: |
             composer install --no-progress
       - run:
+          name: Install SUPREMM RPM build dependencies
+          command: |
+            ./tests/ci/scripts/install_dependencies.sh
+      - run:
           name: Install XDMoD Dependencies
           command: composer install -d $XDMOD_SRC_DIR --no-progress
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,8 @@ jobs:
           name: Run Integration Tests
           command: ./tests/integration_tests/runtests.sh --log-junit ~/phpunit
       - run:
-          name: Run UI Tests
-          command: $XDMOD_SRC_DIR/tests/ui/runtests.sh --headless --log-junit ~/phpunit
-      - run:
           name: Run Regression Tests
           command: ./tests/regression_tests/runtests.sh --log-junit ~/phpunit
-      - store_artifacts:
-          path: /tmp/screenshots
       - store_artifacts:
           path: /var/log/xdmod
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,13 @@ jobs:
           name: Run Integration Tests
           command: ./tests/integration_tests/runtests.sh --log-junit ~/phpunit
       - run:
+          name: Run UI Tests
+          command: scl enable rh-nodejs6 "$XDMOD_SRC_DIR/tests/ui/runtests.sh --headless --log-junit ~/phpunit"
+      - run:
           name: Run Regression Tests
           command: ./tests/regression_tests/runtests.sh --log-junit ~/phpunit
+      - store_artifacts:
+          path: /tmp/screenshots
       - store_artifacts:
           path: /var/log/xdmod
       - store_test_results:

--- a/tests/ci/scripts/install_dependencies.sh
+++ b/tests/ci/scripts/install_dependencies.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$XDMOD_TEST_MODE" = "fresh_install" ];
+then
+    # note this will aslo remmove the existing xdmod-supremm rpm
+    # not a problem since it would have been removed in the xdmod bootstrap
+    # later in the build
+    yum remove -y nodejs npm
+else
+    # The package names are different between the (no longer available) EPEL versions a
+    # the nodesource ones. The xdmod-supremm RPM depends on npm must it must be removed
+    # in order to install the nodesource version. The following will remove it without
+    # uninstalling xdmod-supremm (thus allowing us to test an upgrade). We need the latest
+    # version of nodejs installed in order to generate the RPM.
+    rpm -e --nodeps npm
+fi
+
+yum install -y https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+yum install -y nodejs

--- a/tests/ci/scripts/install_dependencies.sh
+++ b/tests/ci/scripts/install_dependencies.sh
@@ -17,3 +17,8 @@ fi
 
 yum install -y https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 yum install -y nodejs
+
+# The UI tests need nodejs 6 so also install the software collections
+# when the UI tests run they will use the softweare collections version
+yum install -y centos-release-scl-rh
+yum install -y rh-nodejs6

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -12,7 +12,7 @@ BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}__PRERELEASE__-%{relea
 BuildArch:     noarch
 BuildRequires: php-cli
 Requires:      xdmod >= 10.0.0, xdmod < 10.1.0
-Requires:      nodejs npm
+Requires:      nodejs >= 16.13.2
 Requires:      php-pecl-mongo
 
 %description


### PR DESCRIPTION
This changes the RPM dependencies to require nodejs 16 and removes
npm as a dependency (npm is packaged up in the nodesource rpm for
nodejs and also I'm not sure that we even need it!).

Added an extra script for the CI build to make sure the docker
is updated with the correct dependency.

