### PR TITLE
Fixed bug with scatter plot data endpoint to return data if new analytics are added. 

### DIFF
--- a/classes/Rest/Controllers/EfficiencyControllerProvider.php
+++ b/classes/Rest/Controllers/EfficiencyControllerProvider.php
@@ -243,7 +243,7 @@ class EfficiencyControllerProvider extends BaseControllerProvider
                     'success' => true
                 )
             );
-    } else {
+        } else {
             $query = new \DataWarehouse\Query\AggregateQuery(
                 $config->realm,
                 $config->aggregation_unit,

--- a/classes/Rest/Controllers/EfficiencyControllerProvider.php
+++ b/classes/Rest/Controllers/EfficiencyControllerProvider.php
@@ -138,12 +138,7 @@ class EfficiencyControllerProvider extends BaseControllerProvider
             throw new AccessDeniedException('access denied to ' . json_encode($forbiddenStats));
         }
 
-        switch ($analytic) {
-            case 'CPU Usage':
-            case 'GPU Usage':
-            case 'Memory Headroom':
-            case 'Homogeneity':
-            case 'Wall Time Accuracy':
+        if ($analytic !== 'Short Job Count') {
                 $query = new \DataWarehouse\Query\AggregateQuery(
                     $config->realm,
                     $config->aggregation_unit,
@@ -248,7 +243,7 @@ class EfficiencyControllerProvider extends BaseControllerProvider
                         'success' => true
                     )
                 );
-            case "Short Job Count":
+    } else {
                 $query = new \DataWarehouse\Query\AggregateQuery(
                     $config->realm,
                     $config->aggregation_unit,


### PR DESCRIPTION
## Description
Current endpoint only returns data for analytics that are in the configuration file presently. Updated to an if statement rather than a switch statement so by default scatter plot data is returned for any analytics added to the configuration file. 

## Tests performed
Change was tested on metrics-dev. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
