### PR TITLE
Increase composer file cache timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,9 @@ jobs:
             ./tests/ci/scripts/install_dependencies.sh
       - run:
           name: Install XDMoD Dependencies
-          command: composer install -d $XDMOD_SRC_DIR --no-progress
+          command: |
+            composer config -g cache-files-ttl 315360000
+            composer install -d $XDMOD_SRC_DIR --no-progress
       - run:
           name: Create Test Artifact Directories
           command: |


### PR DESCRIPTION
The default timout for files in the composer file cache is 180 days.
Its been a while since we updated some of these dependencies so
composer has been ageing them out and re-downloading. We noticed
that this was happening because there was a seperate issue with
downloading the highcharts dependency files.

This change increases the composer cache timeout so that the cached
files are perferred. This will (slightly) improve the build times
and works-around the (hopefully temporary) problem with the highcharts
download.