### PR TITLE
Added ability to have alternative help text for the histogram.

### DIFF
--- a/html/gui/js/modules/efficiency/AnalyticPanel.js
+++ b/html/gui/js/modules/efficiency/AnalyticPanel.js
@@ -78,7 +78,7 @@ XDMoD.Module.Efficiency.AnalyticPanel = Ext.extend(Ext.Panel, {
         var details = new Ext.Panel({
             region: 'north',
             border: false,
-            html: self.config.documentation
+            html: self.config.documentation.join('')
         });
 
         // South panel to show detailed information about the statistics being shown

--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -616,6 +616,12 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                 }
                 breadcrumbMenu.doLayout();
 
+                //Update help text if alternative histogram text is available
+                if (chartConfig.histogram.histogramHelpText){
+                    var helpText = Ext.getCmp('helpText');
+                    helpText.update(chartConfig.documentation.join(''))
+                }
+
                 // Update the description panel to match the chart being shown
                 var descriptionPanel = Ext.getCmp('descriptionPanel');
                 var commentsTemplate = new Ext.XTemplate(

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -751,6 +751,13 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                                 }
                             }
                         ];
+
+                        //Update help text if alternative histogram text is available
+                        if (self.config.histogram.histogramHelpText){
+                            var helpText = Ext.getCmp('helpText');
+                            helpText.update(self.config.histogram.histogramHelpText.join(''))
+                        }
+
                         self.updateDescription(chartStore);
                     }
                     self.unmask();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds the ability to have independent help text for the histogram view as the help text currently mostly pertains to the scatter plot view. The alternative text is stored in the json file for the analytics (configuration/efficiency_analytics.json).

Fixes this issue - https://app.asana.com/0/1200028182662861/1201717899182390/f.

## Tests performed
Tested on metrics-dev. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
