### PR TITLE
Fix bugs with filtering menu in efficiency tab. 

### DIFF
--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -644,21 +644,27 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                 var filters = Ext.getCmp('analytic_scatter_plot_' + chartConfig.analytic).aggFilters;
 
                 for (i = 0; i < dimensions.length; i++) {
-                    // Get all boxes that were checked in drilldown view and remove the checks
-                    var filterList = Ext.getCmp('checkbox_group' + dimensions[i]).getValue();
+                    // Remove all checks from drilldown view and reset filtersChecked object to be populated by what was previously applied in scatter plot view
+                    var checkboxGroup = Ext.getCmp('checkbox_group' + dimensions[i]).getValue();
                     var j;
-                    for (j = 0; j < filterList.length; j++) {
-                        Ext.getCmp('checkbox_group' + dimensions[i]).setValue(filterList[j].id, false);
+                    for (j = 0; j < checkboxGroup.length; j++) {
+                        checkboxGroup[j].setValue(false);
                     }
+
+                    var fieldSet = Ext.getCmp(dimensions[i] + '_field_set')
+                    fieldSet.filtersChecked = []
 
                     // Check all filters that were applied prior to navigating to the histogram - these are stored in the aggregate filter variable in the scatter plot panel
                     for (var key in filters) {
                         if (Object.prototype.hasOwnProperty.call(filters, key)) {
                             var values = filters[key];
                             if (key === dimensions[i].toLowerCase()) {
+                                var fieldSet = Ext.getCmp(dimensions[i] + '_field_set');
+                                fieldSet.filtersChecked = values;
+
                                 var k;
                                 for (k = 0; k < values.length; k++) {
-                                    Ext.getCmp('checkbox_group' + dimensions[i]).setValue(values[k] + '_' + dimensions[i], true);
+                                    Ext.getCmp('checkbox_group' + dimensions[i]).setValue(values[k].id, true);
                                 }
                             }
                         }

--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -658,7 +658,7 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                             if (key === dimensions[i].toLowerCase()) {
                                 var k;
                                 for (k = 0; k < values.length; k++) {
-                                    Ext.getCmp('checkbox_group' + dimensions[i]).setValue(values[k], true);
+                                    Ext.getCmp('checkbox_group' + dimensions[i]).setValue(values[k] + '_' + dimensions[i], true);
                                 }
                             }
                         }

--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -642,6 +642,7 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                 // Update the filter check boxes to reflect what was checked previously prior to navigating to the histogram
                 var dimensions = ['Queue', 'Application', 'Resource', 'PI'];
                 var filters = Ext.getCmp('analytic_scatter_plot_' + chartConfig.analytic).aggFilters;
+                var fieldSet;
 
                 for (i = 0; i < dimensions.length; i++) {
                     // Remove all checks from drilldown view and reset filtersChecked object to be populated by what was previously applied in scatter plot view
@@ -651,15 +652,14 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                         checkboxGroup[j].setValue(false);
                     }
 
-                    var fieldSet = Ext.getCmp(dimensions[i] + '_field_set')
-                    fieldSet.filtersChecked = []
+                    fieldSet = Ext.getCmp(dimensions[i] + '_field_set');
+                    fieldSet.filtersChecked = [];
 
                     // Check all filters that were applied prior to navigating to the histogram - these are stored in the aggregate filter variable in the scatter plot panel
                     for (var key in filters) {
                         if (Object.prototype.hasOwnProperty.call(filters, key)) {
                             var values = filters[key];
                             if (key === dimensions[i].toLowerCase()) {
-                                var fieldSet = Ext.getCmp(dimensions[i] + '_field_set');
                                 fieldSet.filtersChecked = values;
 
                                 var k;

--- a/html/gui/js/modules/efficiency/FilterPanel.js
+++ b/html/gui/js/modules/efficiency/FilterPanel.js
@@ -51,7 +51,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                                 // Add all filters that are checked in the fieldset for each dimension to a filter object
                                 for (var j = 0; j < fieldSet.length; j++) {
                                     // Add filter to filter list
-                                    filterValues.push(fieldSet[j].id);
+                                    filterValues.push(fieldSet[j].filterId);
 
                                     // Update the string that will be used for chart subtitle
                                     filterSubtitle += fieldSet[j].name;
@@ -62,9 +62,9 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                                     // Create the ME filter object and add to ME filter array
                                     var filterME = {
                                         dimension_id: dimension,
-                                        id: dimension + '=' + fieldSet[j].id,
+                                        id: dimension + '=' + fieldSet[j].filterId,
                                         realms: ['SUPREMM'],
-                                        value_id: fieldSet[j].id,
+                                        value_id: fieldSet[j].filterId,
                                         value_name: fieldSet[j].name,
                                         checked: true
                                     };
@@ -299,7 +299,8 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                             }
 
                             var checkBox = {
-                                id: filters[i].data.id,
+                                id: filters[i].data.id + '_' + dimension,
+                                filterId: filters[i].data.id,
                                 name: filters[i].data.name,
                                 boxLabel: filters[i].data.name,
                                 listeners: {
@@ -413,7 +414,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
 
                     // Check filter if showing, if not showing show all filter checkboxes and check filter
                     if (checkbox_group.items.keys.includes(filter)) {
-                        checkbox_group.setValue(filter, true);
+                        checkbox_group.setValue(filter + '_' + dimension, true);
                     } else {
                         var filterList = Ext.getCmp('checkbox_group' + dimension).getValue();
 
@@ -428,7 +429,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                             Ext.each(filterList, function (f) {
                                 Ext.getCmp('checkbox_group' + dimension).setValue(f.id, true);
                             });
-                            Ext.getCmp('checkbox_group' + dimension).setValue(filter, true);
+                            Ext.getCmp('checkbox_group' + dimension).setValue(filter + '_' + dimension, true);
 
                             fieldSet.getComponent('show_filters_btn_' + dimension).setText('Show Fewer ' + dimension + ' Filters');
                         }, this);

--- a/html/gui/js/modules/efficiency/FilterPanel.js
+++ b/html/gui/js/modules/efficiency/FilterPanel.js
@@ -409,12 +409,12 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
             }),
             listeners: {
                 select: function (e) {
-                    var filter = e.value;
+                    var filterId = e.value + '_' + dimension;
                     var checkbox_group = Ext.getCmp('checkbox_group' + dimension);
 
                     // Check filter if showing, if not showing show all filter checkboxes and check filter
-                    if (checkbox_group.items.keys.includes(filter)) {
-                        checkbox_group.setValue(filter + '_' + dimension, true);
+                    if (checkbox_group.items.keys.includes(filterId)) {
+                        checkbox_group.setValue(filterId, true);
                     } else {
                         var filterList = Ext.getCmp('checkbox_group' + dimension).getValue();
 
@@ -429,7 +429,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                             Ext.each(filterList, function (f) {
                                 Ext.getCmp('checkbox_group' + dimension).setValue(f.id, true);
                             });
-                            Ext.getCmp('checkbox_group' + dimension).setValue(filter + '_' + dimension, true);
+                            Ext.getCmp('checkbox_group' + dimension).setValue(filterId, true);
 
                             fieldSet.getComponent('show_filters_btn_' + dimension).setText('Show Fewer ' + dimension + ' Filters');
                         }, this);

--- a/html/gui/js/modules/efficiency/FilterPanel.js
+++ b/html/gui/js/modules/efficiency/FilterPanel.js
@@ -45,7 +45,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                         for (var i = 0; i < dimensionList.length; i++) {
                             var filterValues = [];
                             // Check each fieldset for filters that a user intends to apply
-                            var fieldSet = Ext.getCmp(dimension + '_field_set')
+                            var fieldSet = Ext.getCmp(dimensionList[i] + '_field_set');
                             var checkedFilters = fieldSet.filtersChecked;
                             if (checkedFilters.length > 0) {
                                 var dimension = dimensionList[i].toLowerCase();
@@ -159,8 +159,8 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                     handler: function () {
                         // Remove any boxes that are checked
                         for (var i = 0; i < dimensionList.length; i++) {
-                            var fieldSet = Ext.getCmp(dimensionList[i] + '_field_set')
-                            fieldSet.filtersChecked = []
+                            var fieldSet = Ext.getCmp(dimensionList[i] + '_field_set');
+                            fieldSet.filtersChecked = [];
 
                             var checkboxGroup = Ext.getCmp('checkbox_group' + dimensionList[i]).getValue();
                             for (var j = 0; j < checkboxGroup.length; j++) {
@@ -383,7 +383,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                             Ext.each(filtersChecked, function (f) {
                                 Ext.getCmp('checkbox_group' + dimension).setValue(f.id, true);
                             });
-                        }, this, { single : true });
+                        }, this, { single: true });
                     }
                 }
             ]
@@ -442,7 +442,7 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                             Ext.getCmp('checkbox_group' + dimension).setValue(filterId, true);
 
                             fieldSet.getComponent('show_filters_btn_' + dimension).setText('Show Fewer ' + dimension + ' Filters');
-                        }, this, { single : true });
+                        }, this, { single: true });
                     }
                 }
             }
@@ -455,16 +455,16 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
     },
 
     // Check handler for filter checkbox - handles enable/disable of apply filters btn
-    onCheck: function (checked) {
+    onCheck: function (checkbox, checked, dimension) {
         var applyFiltersBtn = this.getComponent('button_group').getComponent('apply_filters_btn');
         var fieldSet = Ext.getCmp(dimension + '_field_set');
-        var filtersChecked = Ext.getCmp(dimension + '_field_set').filtersChecked.slice();
+        var filtersChecked = fieldSet.filtersChecked.slice();
 
         if (checked) {
             applyFiltersBtn.enable();
 
             // Add filters that haven't already been added to teh filtersChecked object
-            var filter = filtersChecked.find(function(object) {
+            var filter = filtersChecked.find(function (object) {
                 return object.id === checkbox.id;
             });
 
@@ -473,8 +473,8 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
                 fieldSet.filtersChecked = filtersChecked;
             }
         } else {
-            // Remove any filters that have been stored in the filtersChecked object 
-            var index = filtersChecked.findIndex(function(object) {
+            // Remove any filters that have been stored in the filtersChecked object
+            var index = filtersChecked.findIndex(function (object) {
                 return object.id === checkbox.id;
             });
 
@@ -484,8 +484,8 @@ XDMoD.Module.Efficiency.FilterPanel = Ext.extend(Ext.Panel, {
             var i;
             var filterCount = 0;
             for (i = 0; i < this.dimensions.length; i++) {
-                var fieldSet = Ext.getCmp('checkbox_group' + this.dimensions[i]).getValue();
-                filterCount += fieldSet.length;
+                fieldSet = Ext.getCmp(this.dimensions[i] + '_field_set');
+                filterCount += fieldSet.filtersChecked.length;
             }
 
             if (filterCount === 0) {


### PR DESCRIPTION
## Description
Some filter checkboxes shared ids which caused issues with how filters were populating in the filter menus. Fixed by giving each checkbox a unique id by specifying dimension name in the id field. Filter checkboxes are removed and new checkboxes are populated when navigating between different analytic views, so no ids are being shared in this way.

Filters were not being applied when they were checked if the filter was hidden in the menu. Filters were staying checked due to event handler not being removed after firing event. Set all handlers for showing/more less filter buttons to single and created a new object to store which filters have been checked. Now using that object to apply filters and recheck as needed on showing more or less filters in the menu.  

## Motivation and Context
Fixes issues: 
https://app.asana.com/0/1200028182662861/1201736557183249/f
https://app.asana.com/0/1200028182662861/1201770892992146/f

## Tests performed
Changes tested on metrics-dev. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
