### PR TITLE
Update rpm deps and docs for nodejs EPEL version.

### DIFF
--- a/docs/supremm-install.md
+++ b/docs/supremm-install.md
@@ -22,7 +22,7 @@ The Job Performance (SUPReMM) XDMoD module requires all of the software for XDMo
 the following additional packages:
 
 - [PHP MongoClient][]
-- [nodejs][] 6.14.4+
+- [nodejs][] 16.13.2
 
 [nodejs]:          https://nodejs.org
 [PHP MongoClient]:     http://php.net/manual/en/class.mongoclient.php

--- a/tests/ci/scripts/install_dependencies.sh
+++ b/tests/ci/scripts/install_dependencies.sh
@@ -1,23 +1,5 @@
 #!/bin/bash
 
-if [ "$XDMOD_TEST_MODE" = "fresh_install" ];
-then
-    # note this will aslo remmove the existing xdmod-supremm rpm
-    # not a problem since it would have been removed in the xdmod bootstrap
-    # later in the build
-    yum remove -y nodejs npm
-else
-    # The package names are different between the (no longer available) EPEL versions a
-    # the nodesource ones. The xdmod-supremm RPM depends on npm must it must be removed
-    # in order to install the nodesource version. The following will remove it without
-    # uninstalling xdmod-supremm (thus allowing us to test an upgrade). We need the latest
-    # version of nodejs installed in order to generate the RPM.
-    rpm -e --nodeps npm
-fi
-
-yum install -y https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
-yum install -y nodejs
-
 # The UI tests need nodejs 6 so also install the software collections
 # when the UI tests run they will use the softweare collections version
 yum install -y centos-release-scl-rh

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -13,6 +13,7 @@ BuildArch:     noarch
 BuildRequires: php-cli
 Requires:      xdmod >= 10.0.0, xdmod < 10.1.0
 Requires:      nodejs >= 16.13.2
+BuildRequires: npm >= 8.1.2
 Requires:      php-pecl-mongo
 
 %description


### PR DESCRIPTION
Revert CI build to use the EPEL version of nodejs. Note the previous
RPM had a runtime dependency on npm. This is not actually needed it
is really a build time dependency. The spec file has been updated to
fix this.

Also update the version number in the markdown (should have been done
earlier).