### PR TITLE
Fixed filtering of efficiency charts on duration change.

### DIFF
--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -82,7 +82,7 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
 
                 var scatterPlotPanel = Ext.getCmp('analytic_scatter_plot_' + analytic);
 
-                var filterObj;
+                var filterObj = {};
 
                 // Active item is scatter plot
                 if (activeItemIndex === 0) {
@@ -91,11 +91,18 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                     var analyticConfig = analyticPanel.config;
 
                     // If filters have been applied, keep applied
-                    // Otherwise, only use filters that are needed for initial plot
                     if (scatterPlotPanel.aggFilters) {
-                        filterObj = scatterPlotPanel.aggFilters;
-                    } else {
-                        filterObj = analyticConfig.filters;
+                        var dimensionObj = {};
+                        for (dimension in scatterPlotPanel.aggFilters) {
+                            var filterValues = [];
+
+                            for (var i=0; i<scatterPlotPanel.aggFilters[dimension].length; i++) {
+                                filterValues.push(scatterPlotPanel.aggFilters[dimension][i].filterId);
+                            }
+
+                            dimensionObj[dimension] = filterValues;
+                            jQuery.extend(filterObj, dimensionObj);
+                        }
                     }
 
                     scatterPlotPanel.store.reload({

--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -132,8 +132,8 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
 
                     // If filters have applied, keep applied
                     var filters;
-                    if (scatterPlotPanel.MEFilters) {
-                        filters = scatterPlotPanel.MEFilters.slice();
+                    if (scatterPlotPanel.jobListFilters) {
+                        filters = scatterPlotPanel.jobListFilters.slice();
                         filters.push({
                             dimension_id: 'person',
                             id: 'person=' + personId,
@@ -618,6 +618,9 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
                 scatterPlotPanel.layout.setActiveItem(0);
                 scatterPlotPanel.doLayout();
                 scatterPlotPanel.remove(scatterPlotPanel.items.items[1], true);
+
+                // Remove any stored filters for drilldown plot
+                Ext.getCmp('analytic_scatter_plot_' + chartConfig.analytic).jobListFilters = null;
 
                 // Remove all other links in breadcrumb menu
                 var breadcrumbMenu = Ext.getCmp('breadcrumb_btns');


### PR DESCRIPTION
## Description
There was an error being thrown when you change duration on scatter plot in efficiency tab if filters had been applied prior to changing duration. This error was introduced when filtering bugs were fixed and is caused by how filters were formatted in the parameters object. 

Also, the duration change for the drill down plots was using the wrong filter object causing filters that had been removed from the chart to be reapplied on duration change. 

## Motivation and Context
Fixes a bug introduced by fix for this issue - https://app.asana.com/0/1200028182662861/1201770892992146/f.

## Tests performed
Tested changes on metrics-dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
