### PR TITLE
Add value for max x-axis when restricted data for x-axis has value of 0. 

### DIFF
--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -554,7 +554,7 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
     getMax: function (record, property) {
         var max;
         for (var i = 0; i < record.length; i++) {
-            if (parseFloat(record[i][property])) {
+            if (parseFloat(record[i][property]) || parseFloat(record[i][property]) === 0) {
                 if (max == null || parseFloat(record[i][property]) > max) {
                     max = Math.ceil(parseFloat(record[i][property]));
                 }

--- a/html/gui/js/modules/efficiency/Efficiency.js
+++ b/html/gui/js/modules/efficiency/Efficiency.js
@@ -564,7 +564,7 @@ XDMoD.Module.Efficiency = Ext.extend(XDMoD.PortalModule, {
     getMax: function (record, property) {
         var max;
         for (var i = 0; i < record.length; i++) {
-            if (parseFloat(record[i][property]) || parseFloat(record[i][property]) === 0) {
+            if (record[i][property]) {
                 if (max == null || parseFloat(record[i][property]) > max) {
                     max = Math.ceil(parseFloat(record[i][property]));
                 }

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -474,8 +474,8 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
     getMax: function (record, property) {
         var max;
         for (var i = 0; i < record.length; i++) {
-            if (parseFloat(record[i][property]) || parseFloat(record[i][property]) === 0) {
-                if (!max || parseFloat(record[i][property]) > max) {
+            if (record[i][property]) {
+                if (max == null || parseFloat(record[i][property]) > max) {
                     max = Math.ceil(parseFloat(record[i][property])) + 1;
                 }
             }


### PR DESCRIPTION
## Description
Due to bug with getting max x-axis value in the getMax function in Efficiency.js, any time the returned data for the restricted data had a value of 0 for the x-axis statistic the x-axis max value would return as NaN causing the scatter plot in the analytic cards to not show all of the correct data. 

## Motivation and Context
Bug fix for displaying scatter plots in analytic cards. 

## Tests performed
Changed added to metrics-dev for testing. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
