### PR TITLE
Changed default for unique column for memory usage job list drilldown. 

### DIFF
--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -1081,9 +1081,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                 break;
             default:
                 column = {
-                    renderer: function(){
-                        return null;
-                    }
+                    hidden: true
                 };
         }
 

--- a/html/gui/js/modules/efficiency/ScatterPlotPanel.js
+++ b/html/gui/js/modules/efficiency/ScatterPlotPanel.js
@@ -1040,7 +1040,7 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                     }
                 };
                 break;
-            case 'Memory Headroom':
+            case 'Memory Usage':
                 column = {
                     id: 'max_memory',
                     dataIndex: 'max_memory',
@@ -1080,7 +1080,11 @@ XDMoD.Module.Efficiency.ScatterPlotPanel = Ext.extend(Ext.Panel, {
                 };
                 break;
             default:
-                break;
+                column = {
+                    renderer: function(){
+                        return null;
+                    }
+                };
         }
 
         var rawDataGrid = new Ext.grid.GridPanel({


### PR DESCRIPTION
## Description
The analytic for memory usage was changed from "memory headroom" to "memory usage", but associated change for adding a unique column on memory usage drill down to job list was not made. This change uses the correct term for memory usage in the switch statement when creating a unique column for a specific analytic and updates the default statement to hide the column if analytic is not included in any of the cases for the switch statement. Previous default statement was throwing an error when trying to construct the column to be added to the job list table. Now column is constructed as expected and hidden if no analytic is found in the case statements. 

## Motivation and Context
Fixes bug with this error ```Uncaught TypeError: Cannot read properties of undefined (reading 'id')``` being thrown when trying to view job list table on drill down in memory usage analytic. 

## Tests performed
Tested these changes on metrics-dev. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
