### PR TITLE
Updated image sizing for job efficiency tab customization docs.

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -13,14 +13,14 @@ supporting text giving suggestions of how to improve efficiency regarding a spec
 As of the 10.0 release, there are six analytics. These are CPU Usage, GPU Usage, Memory Usage, Homogeneity, Wall Time Accuracy, and Short Jobs. When you first navigate to the efficiency tab, you will see cards each representing an analytic. Each card includes a brief description of the analytic as well as a scatter plot that allows you to visualize how users rank in each analytic (see Figure 1 below).
 
 <figure>
-<img src="{{ site.baseurl }}/assets/images/efficiency_tab.png" alt="Screenshot of the initial view when first navigating to the efficiency tab. The view shows six cards broken down into two categories - one for usage analytics which includes CPU Usage, GPU Usage, Memory Usage and Homogeneity and one for design analytics which includes Wall Time Accuracy and Short Jobs. Each card displays a short description of the analytic and a thumbnail view of the scatter plot related to that analytic. The scatter plot points represent a user's usage on the resource and efficiency of their jobs for the specific analytic." />
+<img src="{{ site.baseurl }}/assets/images/efficiency_tab.png" width="700" height="400" alt="Screenshot of the initial view when first navigating to the efficiency tab. The view shows six cards broken down into two categories - one for usage analytics which includes CPU Usage, GPU Usage, Memory Usage and Homogeneity and one for design analytics which includes Wall Time Accuracy and Short Jobs. Each card displays a short description of the analytic and a thumbnail view of the scatter plot related to that analytic. The scatter plot points represent a user's usage on the resource and efficiency of their jobs for the specific analytic." />
 <figcaption>Figure 1. Example screenshot of initial view when navigating to the efficiency tab.</figcaption>
 </figure>
 
 Upon clicking on one of the analytic cards, a user will be shown a larger view of the scatter plot that they can interact with by filtering or drilling down. In this view, more text is presented to give more information about the specific analytic and how efficiency may be improved for that analytic. Figure 2 below shows this view for CPU Usage. In this image, you can see the help text at the top of the image above the scatter plot. The associated help text shown in this view can be customized as needed for different centers.
 
 <figure>
-<img src="{{ site.baseurl }}/assets/images/cpu_usage.png" alt="Screenshot of the scatter plot view for CPU Usage in the efficiency tab. Each analytic from the initial efficiency tab page can be viewed in more detail by clicking on the analytic card. This view shows the same scatter plot from the analytic card, but the scatter plot can be filtered or drilled down to learn more information about the users and their respective jobs represented by the scatter plot points. In addition to the scatter plot, there is a side bar that allows filtering and above the scatter plot is the help text explaining the analytic in more detail and giving more information on how to improve efficiency in regard to this analytic." />
+<img src="{{ site.baseurl }}/assets/images/cpu_usage.png" width="700" height="400" alt="Screenshot of the scatter plot view for CPU Usage in the efficiency tab. Each analytic from the initial efficiency tab page can be viewed in more detail by clicking on the analytic card. This view shows the same scatter plot from the analytic card, but the scatter plot can be filtered or drilled down to learn more information about the users and their respective jobs represented by the scatter plot points. In addition to the scatter plot, there is a side bar that allows filtering and above the scatter plot is the help text explaining the analytic in more detail and giving more information on how to improve efficiency in regard to this analytic." />
 <figcaption>Figure 2. Example of CPU Usage scatter plot view and corresponding help text.</figcaption>
 </figure>
 
@@ -117,6 +117,6 @@ In addition to editing the help text, you can also remove an analytic if it is n
 Figure 3 below shows an example of what the updated efficiency tab interface would look like if you were to remove GPU Usage.
 
 <figure>
-<img src="{{ site.baseurl }}/assets/images/efficiency_tab_no_gpu.png" alt="Screenshot of the updated efficiency tab interface after customizing the interface to remove the GPU Usage analytic." />
-<figcaption>Figure 2. Example of an updated efficiency tab interface after removing GPU Usage analytic.</figcaption>
+<img src="{{ site.baseurl }}/assets/images/efficiency_tab_no_gpu.png" width="700" height="400" alt="Screenshot of the updated efficiency tab interface after customizing the interface to remove the GPU Usage analytic." />
+<figcaption>Figure 3. Example of an updated efficiency tab interface after removing GPU Usage analytic.</figcaption>
 </figure>


### PR DESCRIPTION
## Description
Images in efficiency tab customization documentation were not sized properly and were too large for page. This resizes all images to fit within the documentation.  

Documentation added with https://github.com/ubccr/xdmod-supremm/pull/304.

## Motivation and Context
Fixes image sizing so images fit within documentation page without overflowing. 

## Tests performed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
