### PR TITLE
Adding explicit env variable for composer.json

### DIFF
--- a/assets/setup.sh
+++ b/assets/setup.sh
@@ -10,6 +10,6 @@ xdmod_dir="$module_dir/../../.."
 echo Installing Composer dependencies
 cd "$module_dir"
 
-# NOTE: We've added COMPOSER=composer.json while we support both el8 and el7. Once we drop support 
-# for Centos7 then we can remove `COMPOSER=composer.json`. 
+# NOTE: We've added COMPOSER=composer.json while we support both el8 and el7. Once we drop support
+# for Centos7 then we can remove `COMPOSER=composer.json`.
 COMPOSER=composer.json composer install --no-dev

--- a/assets/setup.sh
+++ b/assets/setup.sh
@@ -9,4 +9,7 @@ xdmod_dir="$module_dir/../../.."
 
 echo Installing Composer dependencies
 cd "$module_dir"
+
+# NOTE: We've added COMPOSER=composer.json while we support both el8 and el7. Once we drop support 
+# for Centos7 then we can remove `COMPOSER=composer.json`. 
 COMPOSER=composer.json composer install --no-dev

--- a/assets/setup.sh
+++ b/assets/setup.sh
@@ -9,4 +9,4 @@ xdmod_dir="$module_dir/../../.."
 
 echo Installing Composer dependencies
 cd "$module_dir"
-composer install --no-dev
+COMPOSER=composer.json composer install --no-dev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding an explicit env variable for use when doing a composer install so that `composer.json` is alwayes used. 
There is an accompanying PR in ccr-private-xdmod 181 
## Motivation and Context
Since we merged https://github.com/ubccr/xdmod/pull/1656 we need to make sure that when we do a `composer install` that we explicitly set which file is being used by adding `COMPOSER=<composer file to use> composer install`. Once we drop centos7 support then this can go back to the way it was. 

## Tests performed


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
