### PR TITLE
Update CI build to run the etl mapping tests.

### DIFF
--- a/build.json
+++ b/build.json
@@ -12,7 +12,8 @@
         ],
         "exclude_patterns": [
             "#/\\.#",
-            "#/open_xdmod/modules/supremm/tests#"
+            "#/open_xdmod/modules/supremm/tests#",
+            "#/open_xdmod/modules/supremm/etl/js/config/supremm/tests#"
         ]
     },
     "commands": {

--- a/etl/js/config/supremm/tests/pcp/expected/4655275-1445928790.json
+++ b/etl/js/config/supremm/tests/pcp/expected/4655275-1445928790.json
@@ -380,6 +380,18 @@
         "value": 0,
         "error": 0
     },
+    "gpus": {
+        "value": 0,
+        "error": 8
+    },
+    "gpu_time": {
+        "value": null,
+        "error": 8
+    },
+    "gpu_usage": {
+        "value": null,
+        "error": 8
+    },
     "gpu_energy": {
         "value": null,
         "error": 2

--- a/etl/js/config/supremm/tests/pcp/expected/4843309-1546457856.json
+++ b/etl/js/config/supremm/tests/pcp/expected/4843309-1546457856.json
@@ -374,6 +374,18 @@
         "value": null,
         "error": 8
     },
+    "gpus": {
+        "value": 0,
+        "error": 8
+    },
+    "gpu_time": {
+        "value": null,
+        "error": 8
+    },
+    "gpu_usage": {
+        "value": null,
+        "error": 8
+    },
     "gpu_energy": {
         "value": 657403.674388661,
         "error": 0

--- a/etl/js/config/supremm/tests/pcp/expected/5659085-1469572318.json
+++ b/etl/js/config/supremm/tests/pcp/expected/5659085-1469572318.json
@@ -376,6 +376,18 @@
         "value": 0,
         "error": 0
     },
+    "gpus": {
+        "value": 0,
+        "error": 8
+    },
+    "gpu_time": {
+        "value": null,
+        "error": 8
+    },
+    "gpu_usage": {
+        "value": null,
+        "error": 8
+    },
     "gpu_energy": {
         "value": null,
         "error": 2

--- a/etl/js/config/supremm/tests/pcp/expected/719452-1470861674.json
+++ b/etl/js/config/supremm/tests/pcp/expected/719452-1470861674.json
@@ -375,6 +375,18 @@
         "value": null,
         "error": 8
     },
+    "gpus": {
+        "value": 0,
+        "error": 8
+    },
+    "gpu_time": {
+        "value": null,
+        "error": 8
+    },
+    "gpu_usage": {
+        "value": null,
+        "error": 8
+    },
     "gpu_energy": {
         "value": null,
         "error": 2

--- a/etl/js/config/supremm/tests/pcp/expected/8291026-1518721536.json
+++ b/etl/js/config/supremm/tests/pcp/expected/8291026-1518721536.json
@@ -374,6 +374,18 @@
         "value": null,
         "error": 8
     },
+    "gpus": {
+        "value": 0,
+        "error": 8
+    },
+    "gpu_time": {
+        "value": null,
+        "error": 8
+    },
+    "gpu_usage": {
+        "value": null,
+        "error": 8
+    },
     "gpu_energy": {
         "value": null,
         "error": 2

--- a/tests/ci/scripts/post-install-test.sh
+++ b/tests/ci/scripts/post-install-test.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 
+XDMOD_ETC_DIR="${XDMOD_ETC_DIR:-/etc/xdmod}"
+
 post_install_exit_value=0
+
+echo "Copy ETL Test Artifacts"
+
+mv $XDMOD_ETC_DIR/supremm_resources.json $XDMOD_ETC_DIR/supremm_resources.json_post_install_test
+cp ./configuration/supremm_resources.json $XDMOD_ETC_DIR
+rsync -av ./etl/js/config/supremm/tests/ $XDMOD_INSTALL_DIR/etl/js/config/supremm/tests/
 
 echo "Testing ETL configs..."
 pushd "$XDMOD_INSTALL_DIR" >/dev/null || exit 2
-node etl/js/etl.cli.js -t
+node etl/js/etl.cli.js -t -d
 if [ $? != 0 ]; then
     post_install_exit_value=2
 fi
+
+# revert changes to supremm_resource.json
+mv $XDMOD_ETC_DIR/supremm_resources.json_post_install_test $XDMOD_ETC_DIR/supremm_resources.json
+
 for file in etl/js/config/supremm/unit_test/*.js;
 do
     node $file


### PR DESCRIPTION
    Update CI build to run the etl mapping tests.
    
    This change also removes the test artifacts from the build - they
    do not belong in the production release.
    
    Also, it appears that the test data has not been updated - this
    change also updates the expected results to match the expected
    data.
