### PR TITLE
Use the portal's time zone for raw data query dates instead of UTC.

### DIFF
--- a/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
+++ b/classes/DataWarehouse/Query/SUPREMM/JobDataset.php
@@ -59,7 +59,6 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
         if (isset($parameters['primary_key'])) {
             $this->addPdoWhereCondition(new WhereCondition(new TableField($dataTable, '_id'), "=", $parameters['primary_key']));
         } elseif (isset($parameters['start_date']) && isset($parameters['end_date'])) {
-            date_default_timezone_set('UTC');
             $startDate = date_parse_from_format('Y-m-d', $parameters['start_date']);
             $startDateTs = mktime(
                 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
The same as https://github.com/ubccr/xdmod-xsede/pull/439 but for the `xdmod-supremm` module.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In addition to ensuring the regression tests still pass, I also ran the following steps before https://github.com/ubccr/xdmod-xsede/pull/439 was merged. Now that that PR is merged, the following steps will not produce differences because the changes from that PR are redundant with this one on `xdmod-dev`, since `xdmod-xsede` has a version of the file changed in this PR that overrides this one in `xdmod-supremm`. I'm leaving the steps here for posterity:
1. Run the script from https://github.com/ubccr/xdmod-xsede/pull/436.
1. For the differences in the `SUPREMM` realm:
    1. Copy the "only in old" lines into a file (e.g., named `old`), run  `cut -d',' -f1 -f21 old | cut -d"'" -f2 -f4` to get the Job ID and resource name pairs, and for a sample of these, run the MySQL query below:
        ```
        SELECT from_unixtime(start_time_ts), from_unixtime(end_time_ts)
        FROM modw_supremm.job j
        JOIN modw.resourcefact r
        ON j.resource_id = r.id
        WHERE local_job_id = 'JOB_ID_GOES_HERE'
        AND r.name = 'RESOURCE_NAME_GOES_HERE';
        ```
        and confirm that the end date of the job occurs after 7–8pm on the day before the requested start date, indicating that this job was in the date range when the query used UTC since Eastern Time is 4–5 hours behind UTC.
    1. Do the same for the "only in new" lines, but confirm that the end date of the job occurs after 7–8pm on the requested end date, showing that this job was not in the date range when the query used UTC.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
