### PR TITLE
Fix CircleCI test result paths.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - run:
           name: Create Test Artifact Directories
           command: |
-            mkdir -p /tmp/phpunit
+            mkdir -p ~/phpunit
             mkdir -p /tmp/screenshots
       - run:
           name: Setup Environment Variables
@@ -93,14 +93,14 @@ jobs:
           command: ./tests/ci/scripts/post-install-test.sh
       - run:
           name: Run Component Tests
-          command: ./tests/component_tests/runtests.sh --log-junit ~/phpunit
+          command: ./tests/component_tests/runtests.sh --log-junit ~/phpunit/component.xml
       - run:
           name: Make sure that the Composer Test Dependencies are installed
           command: |
             composer install -d $XDMOD_SRC_DIR --no-progress
       - run:
           name: Run Integration Tests
-          command: ./tests/integration_tests/runtests.sh --log-junit ~/phpunit
+          command: ./tests/integration_tests/runtests.sh --log-junit ~/phpunit/integration.xml
       - run: pushd $HOME && rm -f chromedriver_linux64.zip && wget https://chromedriver.storage.googleapis.com/98.0.4758.80/chromedriver_linux64.zip && popd
       - run:
           name: 'Bodge the nodejs version to run an older one for the webdriver tests'
@@ -116,7 +116,7 @@ jobs:
           command: test ! -e /var/log/php-fpm/www-error.log
       - run:
           name: Run Regression Tests
-          command: ./tests/regression_tests/runtests.sh --log-junit ~/phpunit
+          command: ./tests/regression_tests/runtests.sh --junit-output-dir ~/phpunit
       - store_artifacts:
           path: /tmp/screenshots
       - store_artifacts:
@@ -124,7 +124,7 @@ jobs:
       - store_artifacts:
           path: /var/log/php-fpm
       - store_test_results:
-          path: /tmp/phpunit
+          path: ~/phpunit
 
 workflows:
   full-build:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR fixes the paths to the XML test results in the CircleCI config. Some of the paths were set to `/tmp/phpunit`, and some were set to `~/phpunit`. As a result, the directory `/tmp/phpunit` was created, but the test results were written to `~/phpunit`, which was assumed to be a file rather than a directory, and then CircleCI stored `/tmp/phpunit`, which was empty. This PR sets all of the paths to `~/phpunit` rather than `/tmp/phpunit` to be consistent with the CircleCI config of the `xdmod` repository. It also gives filenames to each of the tests that use `--log-junit` so that the results are saved to files rather than being output to the terminal.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I checked the `build-fresh_install-rocky8` and `build-upgrade-rocky8` checks to make sure the test results show up in the "TESTS" tab, that each of the CircleCI steps that write to `~/phpunit` do not list any errors, and that the "Uploading test results" step archives the following test results:
```
* /root/phpunit/component.xml
* /root/phpunit/integration.xml
* /root/phpunit/xdmod-supremm-regression-centerdirector.xml
* /root/phpunit/xdmod-ui.xml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
