### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/lib/REST/EfficiencyControllerProviderTest.php
+++ b/tests/integration/lib/REST/EfficiencyControllerProviderTest.php
@@ -5,7 +5,7 @@ namespace IntegrationTests\REST;
 use IntegrationTests\BaseTest;
 use IntegrationTests\TestHarness\XdmodTestHelper;
 
-class EfficiencyTest extends BaseTest
+class EfficiencyControllerProviderTest extends BaseTest
 {
     const ENDPOINT = 'rest/v1/efficiency/';
 

--- a/tests/integration/lib/REST/Warehouse/JobViewerTest.php
+++ b/tests/integration/lib/REST/Warehouse/JobViewerTest.php
@@ -408,13 +408,12 @@ class JobViewerTest extends TestCase
         $ret[] = array($xdmodhelper, $searchparams, 'application/pdf', 'application/pdf; charset=binary');
         $searchparams['format'] = 'csv';
 
-        $ret[] = array($xdmodhelper, $searchparams, 'text/csv;charset=UTF-8', 'application/csv; charset=us-ascii');
-
+        $ret[] = array($xdmodhelper, $searchparams, 'text/csv;charset=UTF-8', 'text/plain; charset=us-ascii');
         $searchparams['format'] = 'png';
         $ret[] = array($xdmodhelper, $searchparams, 'image/png', 'image/png; charset=binary');
 
         $searchparams['format'] = 'svg';
-        $ret[] = array($xdmodhelper, $searchparams, 'image/svg+xml', 'image/svg+xml; charset=us-ascii');
+        $ret[] = array($xdmodhelper, $searchparams, 'image/svg+xml', 'image/svg; charset=us-ascii');
 
 
         return $ret;

--- a/tests/integration/lib/REST/internal_dashboard/DashboardSupremmTest.php
+++ b/tests/integration/lib/REST/internal_dashboard/DashboardSupremmTest.php
@@ -9,13 +9,13 @@ class DashboardSupremmTest extends TestCase
 {
     const ENDPOINT = 'rest/v0.1/supremm_dataflow/';
 
-    protected static $helper;
+    protected static $xdmodhelper;
     protected static $validateAsUser;
 
     public static function setUpBeforeClass(): void
     {
         $xdmodConfig = array( "decodetextasjson" => true );
-        self::$helper = new XdmodTestHelper($xdmodConfig);
+        self::$xdmodhelper = new XdmodTestHelper($xdmodConfig);
 
         // validate as manager, for dashboard access
         self::$validateAsUser = 'mgr';
@@ -25,7 +25,7 @@ class DashboardSupremmTest extends TestCase
     {
         // without performing validation: expect to receive a 401;
         // if wrong user authenticated: expect to receive a 403
-        $result = self::$helper->get(self::ENDPOINT . 'resources', $params);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'resources', $params);
 
         // expect success to be false
         $this->assertArrayHasKey('success', $result[0]);
@@ -40,9 +40,9 @@ class DashboardSupremmTest extends TestCase
 
     private function validateSupremmResourceEntries()
     {
-        self::$helper->authenticate(self::$validateAsUser);
+        self::$xdmodhelper->authenticate(self::$validateAsUser);
 
-        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(200, $result[1]['http_code']);
 
         $this->assertArrayHasKey('success', $result[0]);
@@ -73,14 +73,14 @@ class DashboardSupremmTest extends TestCase
     {
         // without performing validation : expect to receive a 401
         // ensure user is logged out
-        self::$helper->logoutDashboard();
+        self::$xdmodhelper->logoutDashboard();
 
         // hardcode the params for resource id
         $params = array(
             'resource_id' => 2791,
             'db_id' => $db
         );
-        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'dbstats', $params);
 
         $this->assertArrayHasKey('success', $result[0]);
         $this->assertFalse($result[0]['success']);
@@ -92,10 +92,10 @@ class DashboardSupremmTest extends TestCase
     private function invalidParamsSupremmDbstatsEntries()
     {
         // validate properly
-        self::$helper->authenticate(self::$validateAsUser);
+        self::$xdmodhelper->authenticate(self::$validateAsUser);
 
         // send null params, expect 400
-        $result = self::$helper->get(self::ENDPOINT . 'dbstats', null);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'dbstats', null);
         $this->assertEquals(400, $result[1]['http_code']);
 
         $this->assertArrayHasKey('success', $result[0]);
@@ -105,14 +105,14 @@ class DashboardSupremmTest extends TestCase
     private function invalidResParamsNotFoundSupremmDbstatsEntries()
     {
         // validate properly
-        self::$helper->authenticate(self::$validateAsUser);
+        self::$xdmodhelper->authenticate(self::$validateAsUser);
 
         // hardcode and send bogus resource_id param
         $params = array(
             'resource_id' => 99999,
             'db_id' => 'summarydb'
         );
-        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'dbstats', $params);
 
         // Message will contain "no result found"
         $this->assertStringContainsString("no result found for the given database", $result[0]['message']);
@@ -128,14 +128,14 @@ class DashboardSupremmTest extends TestCase
     private function invalidParamsNotFoundSupremmDbstatsEntries()
     {
         // validate properly
-        self::$helper->authenticate(self::$validateAsUser);
+        self::$xdmodhelper->authenticate(self::$validateAsUser);
 
         // hardcode and send bogus db_id param
         $params = array(
             'resource_id' => $this->fetchResourceId(),
             'db_id' => 'db_does_not_exist'
         );
-        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'dbstats', $params);
 
         // Message will contain "no result found"
         $this->assertStringContainsString("no result found for the given database", $result[0]['message']);
@@ -160,8 +160,8 @@ class DashboardSupremmTest extends TestCase
         );
 
         // reauthenticate as some (invalid) user role, not a 'mgr' role
-        self::$helper->authenticate($userRole);
-        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
+        self::$xdmodhelper->authenticate($userRole);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'dbstats', $params);
 
         // result has success='false'
         $this->assertArrayHasKey('success', $result[0]);
@@ -173,13 +173,13 @@ class DashboardSupremmTest extends TestCase
 
     private function validateSupremmDbstatsEntries($db)
     {
-        self::$helper->authenticate(self::$validateAsUser);
+        self::$xdmodhelper->authenticate(self::$validateAsUser);
 
         $params = array(
             'resource_id' => $this->fetchResourceId(),
             'db_id' => $db
         );
-        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'dbstats', $params);
         $this->assertEquals(200, $result[1]['http_code']);
 
         // result has success='true'
@@ -197,7 +197,7 @@ class DashboardSupremmTest extends TestCase
     {
         // with wrong user authenticated: expect to receive a 403
         $user = 'cd';
-        self::$helper->authenticate($user);
+        self::$xdmodhelper->authenticate($user);
 
         $result = $this->invalidSupremmResourceEntries(null);
         $this->assertEquals(403, $result[1]['http_code']);
@@ -205,7 +205,7 @@ class DashboardSupremmTest extends TestCase
 
     public function testInvalidUserSupremmResourceEntries()
     {
-        self::$helper->logoutDashboard();
+        self::$xdmodhelper->logoutDashboard();
         // with no user authenticated: expect to receive a 401
         $result = $this->invalidSupremmResourceEntries(null);
         $this->assertEquals(401, $result[1]['http_code']);
@@ -298,19 +298,19 @@ class DashboardSupremmTest extends TestCase
 
     public function testResourceEnableDisable() {
 
-        self::$helper->authenticate(self::$validateAsUser);
+        self::$xdmodhelper->authenticate(self::$validateAsUser);
 
-        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(5, sizeof($result[0]['data']));
 
         shell_exec('mv /etc/xdmod/supremm_resources.json /etc/xdmod/supremm_resources.json.bak && jq \'.resources |= map(if .resource == "frearson" then .enabled |= false else . end)\' /etc/xdmod/supremm_resources.json.bak > /etc/xdmod/supremm_resources.json');
 
-        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(4, sizeof($result[0]['data']));
 
         shell_exec('mv /etc/xdmod/supremm_resources.json.bak /etc/xdmod/supremm_resources.json');
 
-        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
+        $result = self::$xdmodhelper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(5, sizeof($result[0]['data']));
     }
 }

--- a/tests/integration/lib/REST/internal_dashboard/DashboardSupremmTest.php
+++ b/tests/integration/lib/REST/internal_dashboard/DashboardSupremmTest.php
@@ -7,23 +7,25 @@ use PHPUnit\Framework\TestCase;
 
 class DashboardSupremmTest extends TestCase
 {
-    public function __construct($name, $data, $dataName)
+    const ENDPOINT = 'rest/v0.1/supremm_dataflow/';
+
+    protected static $helper;
+    protected static $validateAsUser;
+
+    public static function setUpBeforeClass(): void
     {
         $xdmodConfig = array( "decodetextasjson" => true );
-        $this->xdmodhelper = new XdmodTestHelper($xdmodConfig);
-
-        $this->endpoint = 'rest/v0.1/supremm_dataflow/';
+        self::$helper = new XdmodTestHelper($xdmodConfig);
 
         // validate as manager, for dashboard access
-        $this->validateAsUser = 'mgr';
-        parent::__construct($name, $data, $dataName);
+        self::$validateAsUser = 'mgr';
     }
 
     private function invalidSupremmResourceEntries($params)
     {
         // without performing validation: expect to receive a 401;
         // if wrong user authenticated: expect to receive a 403
-        $result = $this->xdmodhelper->get($this->endpoint . 'resources', $params);
+        $result = self::$helper->get(self::ENDPOINT . 'resources', $params);
 
         // expect success to be false
         $this->assertArrayHasKey('success', $result[0]);
@@ -38,9 +40,9 @@ class DashboardSupremmTest extends TestCase
 
     private function validateSupremmResourceEntries()
     {
-        $this->xdmodhelper->authenticate($this->validateAsUser);
+        self::$helper->authenticate(self::$validateAsUser);
 
-        $result = $this->xdmodhelper->get($this->endpoint . 'resources', null);
+        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(200, $result[1]['http_code']);
 
         $this->assertArrayHasKey('success', $result[0]);
@@ -70,13 +72,15 @@ class DashboardSupremmTest extends TestCase
     private function invalidSupremmDbstatsEntries($db)
     {
         // without performing validation : expect to receive a 401
+        // ensure user is logged out
+        self::$helper->logoutDashboard();
 
         // hardcode the params for resource id
         $params = array(
             'resource_id' => 2791,
             'db_id' => $db
         );
-        $result = $this->xdmodhelper->get($this->endpoint . 'dbstats', $params);
+        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
 
         $this->assertArrayHasKey('success', $result[0]);
         $this->assertFalse($result[0]['success']);
@@ -88,10 +92,10 @@ class DashboardSupremmTest extends TestCase
     private function invalidParamsSupremmDbstatsEntries()
     {
         // validate properly
-        $this->xdmodhelper->authenticate($this->validateAsUser);
+        self::$helper->authenticate(self::$validateAsUser);
 
         // send null params, expect 400
-        $result = $this->xdmodhelper->get($this->endpoint . 'dbstats', null);
+        $result = self::$helper->get(self::ENDPOINT . 'dbstats', null);
         $this->assertEquals(400, $result[1]['http_code']);
 
         $this->assertArrayHasKey('success', $result[0]);
@@ -101,17 +105,17 @@ class DashboardSupremmTest extends TestCase
     private function invalidResParamsNotFoundSupremmDbstatsEntries()
     {
         // validate properly
-        $this->xdmodhelper->authenticate($this->validateAsUser);
+        self::$helper->authenticate(self::$validateAsUser);
 
         // hardcode and send bogus resource_id param
         $params = array(
             'resource_id' => 99999,
             'db_id' => 'summarydb'
         );
-        $result = $this->xdmodhelper->get($this->endpoint . 'dbstats', $params);
+        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
 
         // Message will contain "no result found"
-        $this->assertContains("no result found for the given database", $result[0]['message']);
+        $this->assertStringContainsString("no result found for the given database", $result[0]['message']);
 
         // result has success='false'
         $this->assertArrayHasKey('success', $result[0]);
@@ -124,17 +128,17 @@ class DashboardSupremmTest extends TestCase
     private function invalidParamsNotFoundSupremmDbstatsEntries()
     {
         // validate properly
-        $this->xdmodhelper->authenticate($this->validateAsUser);
+        self::$helper->authenticate(self::$validateAsUser);
 
         // hardcode and send bogus db_id param
         $params = array(
             'resource_id' => $this->fetchResourceId(),
             'db_id' => 'db_does_not_exist'
         );
-        $result = $this->xdmodhelper->get($this->endpoint . 'dbstats', $params);
+        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
 
         // Message will contain "no result found"
-        $this->assertContains("no result found for the given database", $result[0]['message']);
+        $this->assertStringContainsString("no result found for the given database", $result[0]['message']);
 
         // result has success='false'
         $this->assertArrayHasKey('success', $result[0]);
@@ -156,8 +160,8 @@ class DashboardSupremmTest extends TestCase
         );
 
         // reauthenticate as some (invalid) user role, not a 'mgr' role
-        $this->xdmodhelper->authenticate($userRole);
-        $result = $this->xdmodhelper->get($this->endpoint . 'dbstats', $params);
+        self::$helper->authenticate($userRole);
+        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
 
         // result has success='false'
         $this->assertArrayHasKey('success', $result[0]);
@@ -169,13 +173,13 @@ class DashboardSupremmTest extends TestCase
 
     private function validateSupremmDbstatsEntries($db)
     {
-        $this->xdmodhelper->authenticate($this->validateAsUser);
+        self::$helper->authenticate(self::$validateAsUser);
 
         $params = array(
             'resource_id' => $this->fetchResourceId(),
             'db_id' => $db
         );
-        $result = $this->xdmodhelper->get($this->endpoint . 'dbstats', $params);
+        $result = self::$helper->get(self::ENDPOINT . 'dbstats', $params);
         $this->assertEquals(200, $result[1]['http_code']);
 
         // result has success='true'
@@ -193,7 +197,7 @@ class DashboardSupremmTest extends TestCase
     {
         // with wrong user authenticated: expect to receive a 403
         $user = 'cd';
-        $this->xdmodhelper->authenticate($user);
+        self::$helper->authenticate($user);
 
         $result = $this->invalidSupremmResourceEntries(null);
         $this->assertEquals(403, $result[1]['http_code']);
@@ -201,6 +205,7 @@ class DashboardSupremmTest extends TestCase
 
     public function testInvalidUserSupremmResourceEntries()
     {
+        self::$helper->logoutDashboard();
         // with no user authenticated: expect to receive a 401
         $result = $this->invalidSupremmResourceEntries(null);
         $this->assertEquals(401, $result[1]['http_code']);
@@ -258,7 +263,7 @@ class DashboardSupremmTest extends TestCase
     // fetch accountdb stats
     public function testFetchDbstatsAccount($db = 'accountdb') {
 
-        $this->markTestIncomplete('This enpoint only works on the XSEDE version of XDMoD.');
+        $this->markTestIncomplete('This endpoint only works on the XSEDE version of XDMoD.');
 
         $item = $this->validateSupremmDbstatsEntries($db);
 
@@ -293,19 +298,19 @@ class DashboardSupremmTest extends TestCase
 
     public function testResourceEnableDisable() {
 
-        $this->xdmodhelper->authenticate($this->validateAsUser);
+        self::$helper->authenticate(self::$validateAsUser);
 
-        $result = $this->xdmodhelper->get($this->endpoint . 'resources', null);
+        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(5, sizeof($result[0]['data']));
 
         shell_exec('mv /etc/xdmod/supremm_resources.json /etc/xdmod/supremm_resources.json.bak && jq \'.resources |= map(if .resource == "frearson" then .enabled |= false else . end)\' /etc/xdmod/supremm_resources.json.bak > /etc/xdmod/supremm_resources.json');
 
-        $result = $this->xdmodhelper->get($this->endpoint . 'resources', null);
+        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(4, sizeof($result[0]['data']));
 
         shell_exec('mv /etc/xdmod/supremm_resources.json.bak /etc/xdmod/supremm_resources.json');
 
-        $result = $this->xdmodhelper->get($this->endpoint . 'resources', null);
+        $result = self::$helper->get(self::ENDPOINT . 'resources', null);
         $this->assertEquals(5, sizeof($result[0]['data']));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a silently failing integration test that also blocked other tests from running. It also fixes the subsequent failing tests that were masked by this bug. This PR does not fix the high-level problem that the integration tests silently fail when a test class is not properly constructed, but I believe that should be addressed in a separate PR.

## Description
<!--- Describe your changes in detail -->
* Refactor internal dashboard test to properly set up the test
* Fix the content-type that the test is comparing to match Rocky 8 tests from before. There was previously logic to compare different content-types returned by the different operating systems (CentOS 7 and Rocky 8). These content-types rules for Rocky 8 were not properly copied before and caused the tests to erroneously fail. More info [here](https://github.com/ubccr/xdmod-supremm/pull/373/files#diff-db90236cb14dda42665bde3339f5cc9603f0a336580bd475c1739032b9234d92L402).
* Fix a warning in the `EfficiencyControllerProviderTest` by matching the test class to the test's filename

<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This bug in the test was introduced in https://github.com/ubccr/xdmod-supremm/pull/373 with the upgrade from `phpunit` version ~4 to version 9.6.

Arguments are passed to that test class's constructor, however `phpunit`'s TestCase class does not accept any arguments and causes the test to fail. This is problematic because the test fails silently and does not execute the other tests. This is silently failing error from the test:
```
{"success":false,"count":0,"total":0,"totalCount":0,"results":[],"data":[],"message":"Too few arguments to function IntegrationTests\\REST\\internal_dashboard\\DashboardSupremmTest::__construct(), 0 passed in \/root\/xdmod\/vendor\/phpunit\/phpunit\/src\/Framework\/TestBuilder.php on line 138 and exactly 3 expected","code":0}
```
In addition to this test failing, there were subsequent tests that were also failing but never got executed. This PR includes fixes for those tests as well.

<!--- If it fixes an open issue, please link to the issue here. -->
https://app.asana.com/0/159049597309611/1208001546005416

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested by running the integration test `runtests.sh` script in a container and verifying that all tests pass.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
