### PR TITLE
Fix release date of v11.0.0 in changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Open XDMoD SUPReMM Change Log
 =============================
 
-## 2024-09-11 v11.0.0
+## 2024-XX-XX v11.0.0
 
 - Features
     - Add GPU Count group by ([\#379](https://github.com/ubccr/xdmod-supremm/pull/379))


### PR DESCRIPTION
This PR updates the changelog to set the release date for v11.0.0 back to `2024-XX-XX` since it has not been released yet.