### PR TITLE
Fix menu links.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ defaults:
       sw_version: "11.0.0"
       summ_sw_version: "2.0.0"
       style: "effervescence"
-      tocversion: "v10_5toc"
+      tocversion: "v11_0toc"
   -
     scope:
       path: "10.5"


### PR DESCRIPTION
This PR fixes the links in the menu on https://supremm.xdmod.org. Currently they point to the 10.5 versions of the pages instead of the 11.0 versions of the pages.