### PR TITLE
Prep for v11.0.1 development.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: dnf install -y php libzip-devel php-pear
       - run:
           name: Install MongoDB Pear module
-          command: yes '' | pecl install mongodb || true
+          command: yes '' | pecl install mongodb-1.16.2 || true
       - run:
           name: Add mongodb
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,6 @@ jobs:
           name: Install PHP 7.4 && Pear pre-reqs
           command: dnf install -y php libzip-devel php-pear
       - run:
-          name: Install MongoDB Pear module
-          command: yes '' | pecl install mongodb-1.16.2 || true
-      - run:
           name: Add mongodb
           command: |
               ./tests/ci/scripts/install_mongo.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Open XDMoD SUPReMM Change Log
 =============================
 
+## v11.0.1 development branch
+
 ## 2024-09-16 v11.0.0
 
 - Features

--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod-supremm",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ description: >
   memory usage, filesystem usage, interconnect fabric traffic, and CPU
   performance.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://supremm.xdmod.org" # the base hostname & protocol for your site
+url: "https://supremm.xdmod.org" # the base hostname & protocol for your site
 github_username: ubccr
 github_url: https://github.com/ubccr/xdmod-supremm
 xdmod_module_name: Job Performance (SUPReMM)
@@ -35,10 +35,10 @@ defaults:
     values:
       layout: "page"
       version: "11.0"
-      sw_version: "11.0.0"
+      sw_version: "11.0.1"
       summ_sw_version: "2.0.0"
       style: "effervescence"
-      tocversion: "toc"
+      tocversion: "v11_0toc"
 
 # Build settings
 markdown: kramdown

--- a/docs/supremm-upgrade.md
+++ b/docs/supremm-upgrade.md
@@ -33,4 +33,7 @@ The upgrade script will update the following configuration files:
 The upgrade script will add rows to the `modw_supremm.application` table for
 the MOM6, ROMS, NEXMD, Libra, DFTB+, and CDO applications.
 
+11.0.1 Upgrade Notes
+--------------------
+
 [github-latest-release]: https://github.com/ubccr/xdmod-supremm/releases/latest

--- a/tests/ci/scripts/install_mongo.sh
+++ b/tests/ci/scripts/install_mongo.sh
@@ -13,6 +13,6 @@ EOF
 
 dnf install -y mongodb-org php-devel
 
-pecl install mongodb-1.16.2
+pecl install mongodb-1.18.1
 
 echo "extension=mongodb.so" > /etc/php.d/40-mongodb.ini


### PR DESCRIPTION
This PR prepares the `xdmod11.0` branch for development of version `11.0.1`. It depends on https://github.com/ubccr/xdmod/pull/1939.