### PR TITLE
Update changelog for 11.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Open XDMoD SUPReMM Change Log
 =============================
 
-## XXXX-XX-XX v11.5.0
-
 ## 2025-03-17 v11.0.1
 
 - Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Open XDMoD SUPReMM Change Log
 =============================
 
+## XXXX-XX-XX v11.5.0
+
 ## 2024-09-16 v11.0.0
 
 - Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Open XDMoD SUPReMM Change Log
 
 ## XXXX-XX-XX v11.5.0
 
-## XXXX-XX-XX v11.0.1
+## 2025-03-17 v11.0.1
 
 - Documentation
     - Add link to GitHub downloads page in upgrade docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Open XDMoD SUPReMM Change Log
 
 ## XXXX-XX-XX v11.5.0
 
+## XXXX-XX-XX v11.0.1
+
+- Documentation
+    - Add link to GitHub downloads page in upgrade docs
+      ([\#398](https://github.com/ubccr/xdmod-supremm/pull/398)).
+
 ## 2024-09-16 v11.0.0
 
 - Features

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "name": "xdmod-supremm",
     "version": "11.5.0",
-    "release": "1.0",
+    "release": "1",
     "files": {
         "include_paths": [
         ],

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ description: >
   memory usage, filesystem usage, interconnect fabric traffic, and CPU
   performance.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://supremm.xdmod.org" # the base hostname & protocol for your site
+url: "https://supremm.xdmod.org" # the base hostname & protocol for your site
 github_username: ubccr
 github_url: https://github.com/ubccr/xdmod-supremm
 xdmod_module_name: Job Performance (SUPReMM)

--- a/xdmod-supremm.spec.in
+++ b/xdmod-supremm.spec.in
@@ -59,38 +59,40 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xdmod/efficiency_analytics.json
 
 %changelog
+* Mon Mar 17 2025 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1
+- Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
-    - Release 11.0.0
-    - Remove `php-pecl-mongo` from required dependencies
+- Release 11.0.0
+- Remove `php-pecl-mongo` from required dependencies
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
-    - Release 10.5.0
+- Release 10.5.0
 * Thu May 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.1-1.0
-    - Release 10.0.1
+- Release 10.0.1
 * Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
-    - Release 10.0.0
+- Release 10.0.0
 * Fri May 21 2021 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
-    - Release 9.5.0
+- Release 9.5.0
 * Thu Aug 13 2020 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.0.0-1.0
-    - Release 9.0.0
+- Release 9.0.0
 * Mon Oct 21 2019 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 8.5.0-1.0
-    - Release 8.5.0.
+- Release 8.5.0.
 * Tue Apr 23 2019 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 8.1.0-1.0
-    - Release 8.1.0.
+- Release 8.1.0.
 * Thu Nov 8 2018 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 8.0.0-1.0
-    - Release 8.0.0.
+- Release 8.0.0.
 * Wed Mar 14 2018 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 7.5.1-1.0
-    - Release 7.5.1.
+- Release 7.5.1.
 * Thu Mar 01 2018 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 7.5.0-1.0
-    - Release 7.5.0.
+- Release 7.5.0.
 * Thu Sep 21 2017 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 7.0.0-1.0
-    - Release 7.0.0.
+- Release 7.0.0.
 * Thu May 11 2017 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 6.6.0-1.0
-    - Release 6.6.0.
+- Release 6.6.0.
 * Tue Jan 10 2017 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 6.5.0-1.0
-    - Release 6.5.0.
+- Release 6.5.0.
 * Wed Sep 21 2016 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 6.0.0-1.0
-    - Release 6.0.0.
+- Release 6.0.0.
 * Tue May 24 2016 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 5.6.0-1.0
-    - Release 5.6.0.
+- Release 5.6.0.
 * Fri Dec 18 2015 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 5.5.0-0.6.beta1
-    - Initial public release
+- Initial public release


### PR DESCRIPTION
Port of https://github.com/ubccr/xdmod-supremm/pull/406 for the `main` branch.