### PR TITLE
Update docs. (#422)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,9 @@ defaults:
       layout: "page"
       version: "10.5"
       sw_version: "10.5.1"
+      rpm_version: "10.5.1-1"
       summ_sw_version: "2.0.0"
+      summ_rpm_version: "2.0.0-1"
       style: "effervescence"
       tocversion: "toc"
 

--- a/docs/supremm-install.md
+++ b/docs/supremm-install.md
@@ -11,29 +11,32 @@ follow the instructions in the [Upgrade Guide](supremm-upgrade.html).
 RPM Installation
 ----------------
 
-An RPM package for Rocky 8 is [available for download](https://github.com/ubccr/xdmod-supremm/releases/tag/{{ page.sw_version }}-1.0).
+If your web server can reach GitHub via HTTPS, you can install the RPM package
+directly:
 
-    # dnf install xdmod-supremm-{{ page.sw_version }}-1.0.el8.noarch.rpm
+    # dnf install https://github.com/ubccr/xdmod-supremm/releases/download/v{{ page.rpm_version }}/xdmod-supremm-{{ page.rpm_version }}.el8.noarch.rpm
+
+Otherwise, you can download the RPM file from the [GitHub page for the
+release](https://github.com/ubccr/xdmod-supremm/releases/tag/v{{
+page.rpm_version }}) and install it:
+
+    # dnf install xdmod-supremm-{{ page.rpm_version }}.el8.noarch.rpm
 
 Source Installation
 -------------------
 
-The Job Performance (SUPReMM) XDMoD module requires all of the software for XDMoD and
-the following additional packages:
-
-- [PHP MongoClient][]
-- [nodejs][] 16.13.2
-
-[nodejs]:          https://nodejs.org
-[PHP MongoClient]:     http://php.net/manual/en/class.mongoclient.php
-
-    $ tar zxvf xdmod-supremm-{{ page.sw_version }}.tar.gz
-    $ cd xdmod-supremm-{{ page.sw_version }}
-    # ./install -prefix=/opt/xdmod
+The source package can be downloaded from
+[GitHub](https://github.com/ubccr/xdmod-supremm/releases/tag/v{{ page.rpm_version }}).
+Make sure to download `xdmod-supremm-{{ page.sw_version }}.tar.gz`, not the
+GitHub-generated "Source code" files.
 
 **NOTE**: The installation prefix must be the same as your existing Open
 XDMoD installation. These instructions assume you have already installed
-Open XDMoD in `/opt/xdmod`.
+Open XDMoD in `/opt/xdmod-{{ page.sw_version }}`.
+
+    # tar zxvf xdmod-supremm-{{ page.sw_version }}.tar.gz
+    # cd xdmod-supremm-{{ page.sw_version }}
+    # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 Additional Notes
 ----------------

--- a/docs/supremm-processing-install.md
+++ b/docs/supremm-processing-install.md
@@ -21,7 +21,7 @@ PowerTools repositories. These can be added with the following commands:
 
 An RPM package is [available for download](https://github.com/ubccr/supremm/releases/tag/{{ page.summ_sw_version }}).
 
-    # dnf install supremm-{{ page.summ_sw_version }}-1.el8.x86_64.rpm
+    # dnf install supremm-{{ page.summ_rpm_version }}.el8.x86_64.rpm
 
 ## Source Installation
 

--- a/docs/supremm-processing-upgrade.md
+++ b/docs/supremm-processing-upgrade.md
@@ -15,7 +15,7 @@ The upgrade procedure involves installing the new software package. An RPM is
 provided for Rocky 8 and is compiled against the version of PCP that ships with
 the distribution (PCP version 5.3.7).
 
-    # dnf install supremm-{{ page.summ_sw_version }}-1.el8.x86_64.rpm
+    # dnf install supremm-{{ page.summ_rpm_version }}.el8.x86_64.rpm
 
 ### Source code upgrade
 

--- a/docs/supremm-upgrade.md
+++ b/docs/supremm-upgrade.md
@@ -5,13 +5,15 @@ title: SUPReMM Open XDMoD module Upgrade Guide
 General Upgrade Notes
 ---------------------
 
-The Job Performance (SUPReMM) XDMoD module should be upgraded at the same time as the main XDMoD
-software. The upgrade procedure is documented on the [XDMoD upgrade
+The Job Performance (SUPReMM) XDMoD module should be upgraded at the same time as the main Open XDMoD
+software. The upgrade procedure is documented on the [Open XDMoD upgrade
 page](https://open.xdmod.org/upgrade.html). Downloads of RPMs and source
 packages for the Job Performance (SUPReMM) XDMoD module are available from
-[GitHub][github-latest-release]. The ingestion and aggregation
-script `aggregate_supremm.sh` **must** be run after the XDMoD software has been
-upgraded.
+[GitHub][github-release]. The ingestion and aggregation
+script `aggregate_supremm.sh` **must** be run after the Open XDMoD software has
+been upgraded.
 
 Note that if you edited the `application.json` file you will need to re-apply
 these edits every time you upgrade as noted on [this page](customization.md).
+
+[github-release]: https://github.com/ubccr/xdmod-supremm/releases/tag/v{{ page.rpm_version }}


### PR DESCRIPTION
Backport of https://github.com/ubccr/xdmod-supremm/pull/422 for the `xdmod10.5` branch.